### PR TITLE
Add in-app setup wizard: pick a repo, check/fix its git identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: CI
 
 on:
+  # Only main gets its own push trigger — a feature branch with an open PR
+  # already gets CI from `pull_request` below, so triggering `push` for every
+  # branch double-runs the whole suite (once per event) on every commit to an
+  # open PR. Restricting push to main is the standard fix: main itself is
+  # never a PR head here, so it can't double-fire the other way either.
   push:
+    branches: [main]
   pull_request:
 
 # Cancel superseded runs on the same branch/PR to save CI minutes.

--- a/src-tauri/src/identity.rs
+++ b/src-tauri/src/identity.rs
@@ -1,0 +1,109 @@
+//! Repo-local git identity (user.name/user.email) — setup wizard.
+//!
+//! Every read/write here passes an explicit `--local` to the git CLI, so it
+//! can NEVER read or write `~/.gitconfig` or the system config — stricter
+//! than rerere::rerere_set_enabled's reliance on plain `git config`'s
+//! local-by-default behavior. git2::Config is deliberately NOT used: its
+//! layered-config API makes "local only" a matter of picking the right
+//! ConfigLevel correctly, whereas `--local` on the CLI is an explicit,
+//! unambiguous, well-documented restriction (same read/write-via-CLI split
+//! as git_write.rs and safety.rs — libgit2 is for reads elsewhere, never for
+//! identity mutation here).
+
+use git2::Repository;
+use serde::Serialize;
+
+use crate::git_write::WriteResult;
+use crate::safety::{self, GitOut};
+
+#[derive(Serialize, Clone, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct GitIdentity {
+    pub name: Option<String>,
+    pub email: Option<String>,
+    /// true only when BOTH name and email are set in this repo's local config.
+    pub configured: bool,
+}
+
+/// JS: `commands.getGitIdentity(path)` -> `Promise<Result<GitIdentity,string>>`.
+/// Fails only if `path` isn't a git repository at all (used by the setup
+/// wizard as its directory-validation step, doubling as the identity check).
+#[tauri::command]
+#[specta::specta]
+pub fn get_git_identity(path: String) -> Result<GitIdentity, String> {
+    Repository::open(&path)
+        .map_err(|e| format!("That doesn't look like a git repository — {}", e.message()))?;
+    let name = read_local(&path, "user.name");
+    let email = read_local(&path, "user.email");
+    let configured = name.is_some() && email.is_some();
+    Ok(GitIdentity { name, email, configured })
+}
+
+fn read_local(path: &str, key: &str) -> Option<String> {
+    let out = safety::run_git(path, &["config", "--local", "--get", key]).ok()?;
+    if !out.ok {
+        return None; // unset locally (git exits 1) — not an error
+    }
+    let v = out.stdout.trim();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v.to_string())
+    }
+}
+
+/// JS: `commands.setGitIdentity(path, name, email)` -> `Promise<WriteResult>`
+/// (never rejects; `ok:false` + message on failure). Writes ONLY this repo's
+/// local config (never `--global`). Non-destructive metadata, no ref/history
+/// touched, so — per the safety-model convention used by rerere_set_enabled —
+/// this does NOT take a Safety Manager snapshot first.
+#[tauri::command]
+#[specta::specta]
+pub fn set_git_identity(path: String, name: String, email: String) -> WriteResult {
+    if let Err(e) = Repository::open(&path) {
+        return WriteResult {
+            ok: false,
+            message: format!("Cannot open repository: {}", e.message()),
+            backup_ref: None,
+        };
+    }
+    let name = name.trim();
+    let email = email.trim();
+    if name.is_empty() || email.is_empty() {
+        return WriteResult {
+            ok: false,
+            message: "Name and email must not be empty.".to_string(),
+            backup_ref: None,
+        };
+    }
+    if let Err(msg) = write_local(&path, "user.name", name) {
+        return WriteResult { ok: false, message: msg, backup_ref: None };
+    }
+    if let Err(msg) = write_local(&path, "user.email", email) {
+        return WriteResult { ok: false, message: msg, backup_ref: None };
+    }
+    WriteResult {
+        ok: true,
+        message: format!("Set identity for this repository: {name} <{email}>."),
+        backup_ref: None,
+    }
+}
+
+fn write_local(path: &str, key: &str, value: &str) -> Result<(), String> {
+    match safety::run_git(path, &["config", "--local", key, value]) {
+        Ok(out) if out.ok => Ok(()),
+        Ok(out) => Err(err_msg(&out)),
+        Err(e) => Err(e),
+    }
+}
+
+/// Best human message from a failed git run (prefer stderr).
+fn err_msg(o: &GitOut) -> String {
+    if !o.stderr.is_empty() {
+        o.stderr.clone()
+    } else if !o.stdout.is_empty() {
+        o.stdout.clone()
+    } else {
+        format!("git exited with status {}", o.code)
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod git_write;
 pub mod git_bisect; // M3: git bisect (start / mark good|bad|skip / status / reset)
 pub mod git_merge; // M6 (stage 1): merge (drag-onto-HEAD) + continue / abort
 pub mod git_rebase; // M6 (stage 2): linear rebase onto a target + continue / skip / abort
+pub mod identity; // Setup wizard: repo-local git identity (user.name/user.email) check + fix
 pub mod layout;
 pub mod model;
 pub mod plumbing; // M5b: read-only object-database inspector (commit/tree/blob/tag by rev)
@@ -67,6 +68,9 @@ fn specta_builder() -> Builder<tauri::Wry> {
         filter_repo::filter_repo_run,
         filter_repo::filter_repo_restore,
         filter_repo::filter_repo_list_backups,
+        // Setup wizard: repo-local git identity check + fix (never touches global config)
+        identity::get_git_identity,
+        identity::set_git_identity,
     ])
 }
 

--- a/src-tauri/tests/identity.rs
+++ b/src-tauri/tests/identity.rs
@@ -1,0 +1,165 @@
+//! Setup wizard's git identity commands — real end-to-end coverage against an
+//! actual `git` binary and a throwaway repo (see `tests/common/mod.rs`).
+//!
+//! The most important property under test is that `set_git_identity` NEVER
+//! writes the host's real global git config. `get_git_identity`/
+//! `set_git_identity` always pass an explicit `--local` to the git CLI, which
+//! is documented, unambiguous scoping — this suite proves it two ways: (a)
+//! the written value round-trips through `git config --local --get` on the
+//! temp repo, and (b) the host's REAL global `user.name`/`user.email` (read,
+//! never written, via a plain unscoped `git config --global --get`) are
+//! byte-identical before and after. (b) deliberately never writes anywhere
+//! outside the temp repo, so it's safe to run on a developer machine or CI
+//! runner with a real ~/.gitconfig.
+
+mod common;
+
+use common::TempRepo;
+use gitcat_lib::identity::{get_git_identity, set_git_identity};
+
+/// Read the host's REAL global config (not `TempRepo::git`, which isolates
+/// `GIT_CONFIG_GLOBAL` to `/dev/null` for its own calls — we want the actual
+/// ambient value here, precisely so we can prove it's untouched). Returns
+/// `None` if the key isn't set globally at all.
+fn real_global(key: &str) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["config", "--global", "--get", key])
+        .output()
+        .expect("failed to run git");
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+#[test]
+fn get_git_identity_reports_the_repo_local_identity_temprepo_already_sets() {
+    let repo = TempRepo::init("identity_read");
+    let path = repo.path();
+
+    // TempRepo::init already sets a repo-local identity (see common/mod.rs).
+    let id = get_git_identity(path).expect("get_git_identity failed");
+    assert!(id.configured);
+    assert_eq!(id.name.as_deref(), Some("GitCat Test"));
+    assert_eq!(id.email.as_deref(), Some("test@gitcat.example"));
+}
+
+#[test]
+fn get_git_identity_reports_unconfigured_when_local_identity_is_unset() {
+    let repo = TempRepo::init("identity_unset");
+    repo.must(&["config", "--local", "--unset", "user.name"]);
+    repo.must(&["config", "--local", "--unset", "user.email"]);
+    let path = repo.path();
+
+    let id = get_git_identity(path).expect("get_git_identity failed");
+    assert!(!id.configured);
+    assert_eq!(id.name, None);
+    assert_eq!(id.email, None);
+}
+
+#[test]
+fn get_git_identity_reports_partial_identity_as_unconfigured() {
+    let repo = TempRepo::init("identity_partial");
+    repo.must(&["config", "--local", "--unset", "user.email"]);
+    let path = repo.path();
+
+    let id = get_git_identity(path).expect("get_git_identity failed");
+    assert!(!id.configured, "only name is set — configured must be false");
+    assert_eq!(id.name.as_deref(), Some("GitCat Test"));
+    assert_eq!(id.email, None);
+}
+
+#[test]
+fn get_git_identity_errors_on_a_path_that_is_not_a_repository() {
+    let dir = std::env::temp_dir().join(format!(
+        "gitcat-test-not-a-repo-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir scratch dir");
+
+    let result = get_git_identity(dir.to_string_lossy().to_string());
+    assert!(result.is_err(), "a non-repository path must error");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn set_git_identity_writes_local_config_and_never_touches_the_real_global_config() {
+    let repo = TempRepo::init("identity_write");
+    repo.must(&["config", "--local", "--unset", "user.name"]);
+    repo.must(&["config", "--local", "--unset", "user.email"]);
+    let path = repo.path();
+
+    // Snapshot the REAL global config before touching anything.
+    let global_name_before = real_global("user.name");
+    let global_email_before = real_global("user.email");
+
+    let res = set_git_identity(
+        path.clone(),
+        "Setup Wizard Test User".to_string(),
+        "setup-wizard-test@example.invalid".to_string(),
+    );
+    assert!(res.ok, "set_git_identity failed: {}", res.message);
+
+    // (a) the value landed in THIS repo's local config.
+    let (_, local_name, _) = repo.git(&["config", "--local", "--get", "user.name"]);
+    let (_, local_email, _) = repo.git(&["config", "--local", "--get", "user.email"]);
+    assert_eq!(local_name.trim(), "Setup Wizard Test User");
+    assert_eq!(local_email.trim(), "setup-wizard-test@example.invalid");
+
+    // Cross-check via get_git_identity too.
+    let id = get_git_identity(path).expect("get_git_identity failed");
+    assert!(id.configured);
+    assert_eq!(id.name.as_deref(), Some("Setup Wizard Test User"));
+    assert_eq!(id.email.as_deref(), Some("setup-wizard-test@example.invalid"));
+
+    // (b) the REAL global config is byte-identical to before — proves the
+    // write never escaped `--local`.
+    let global_name_after = real_global("user.name");
+    let global_email_after = real_global("user.email");
+    assert_eq!(global_name_before, global_name_after, "global user.name must be untouched");
+    assert_eq!(global_email_before, global_email_after, "global user.email must be untouched");
+}
+
+#[test]
+fn set_git_identity_rejects_empty_name_or_email() {
+    let repo = TempRepo::init("identity_empty");
+    let path = repo.path();
+
+    let res = set_git_identity(path.clone(), "  ".to_string(), "a@b.c".to_string());
+    assert!(!res.ok, "blank name must be rejected");
+
+    let res = set_git_identity(path, "A".to_string(), "  ".to_string());
+    assert!(!res.ok, "blank email must be rejected");
+}
+
+#[test]
+fn set_git_identity_errors_on_a_path_that_is_not_a_repository() {
+    let dir = std::env::temp_dir().join(format!(
+        "gitcat-test-not-a-repo-write-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).expect("mkdir scratch dir");
+
+    let res = set_git_identity(
+        dir.to_string_lossy().to_string(),
+        "A".to_string(),
+        "a@b.c".to_string(),
+    );
+    assert!(!res.ok, "a non-repository path must fail, not panic");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -388,6 +388,29 @@ async filterRepoListBackups(path: string) : Promise<Result<FilterRepoBackupInfo[
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * JS: `commands.getGitIdentity(path)` -> `Promise<Result<GitIdentity,string>>`.
+ * Fails only if `path` isn't a git repository at all (used by the setup
+ * wizard as its directory-validation step, doubling as the identity check).
+ */
+async getGitIdentity(path: string) : Promise<Result<GitIdentity, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_git_identity", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * JS: `commands.setGitIdentity(path, name, email)` -> `Promise<WriteResult>`
+ * (never rejects; `ok:false` + message on failure). Writes ONLY this repo's
+ * local config (never `--global`). Non-destructive metadata, no ref/history
+ * touched, so — per the safety-model convention used by rerere_set_enabled —
+ * this does NOT take a Safety Manager snapshot first.
+ */
+async setGitIdentity(path: string, name: string, email: string) : Promise<WriteResult> {
+    return await TAURI_INVOKE("set_git_identity", { path, name, email });
 }
 }
 
@@ -484,6 +507,11 @@ touchedCommits: number }
  * Rust `Err`) — see module docs on the failure model.
  */
 export type FilterRepoResult = { ok: boolean; message: string; backupBundle: string | null; commitsBefore: number | null; commitsAfter: number | null }
+export type GitIdentity = { name: string | null; email: string | null; 
+/**
+ * true only when BOTH name and email are set in this repo's local config.
+ */
+configured: boolean }
 /**
  * The full graph payload. Rows are in reverse-chronological/topological order
  * (child before parent). `lane`/`color`/`merge` are one-per-row.

--- a/src/islands/setupwizard/SetupWizard.svelte
+++ b/src/islands/setupwizard/SetupWizard.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  // Setup wizard — view. Deliberately NO <style> block: reuses the existing
+  // global .scrim/.modal/.msteps/.confirm-type/.pl-err/.pl-kv/.hero-hint
+  // classes (see index.html / FilterRepo.svelte), so this looks consistent
+  // with the rest of the app's chrome. Mounted straight to document.body
+  // (like Resolver/Bisect/FilterRepo), as an overlay on top of whatever
+  // legacy/main.ts already rendered underneath (the hero card, or the demo
+  // graph) — Esc/Skip just reveals what's already there.
+  import { setupWizardCtrl, type SetupWizardStep } from "./setupwizard.svelte.ts";
+
+  const STEP_ORDER: SetupWizardStep[] = ["welcome", "pick", "identity", "done"];
+
+  function stepIndex(): number {
+    return STEP_ORDER.indexOf(setupWizardCtrl.step);
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key !== "Escape" || !setupWizardCtrl.open) return;
+    if (setupWizardCtrl.busy) return; // don't strand an in-flight dialog/save/open
+    setupWizardCtrl.skip();
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<div class="scrim" id="setupWizardScrim" class:on={setupWizardCtrl.open}>
+  <div class="modal">
+    <div class="modal-head">
+      <div class="modal-tama"><img class="tama-pic" src={setupWizardCtrl.tamaImg} alt="Tama" /></div>
+      <div>
+        <h3>Let's get you set up</h3>
+        <p>
+          {#if setupWizardCtrl.step === "welcome"}
+            はじめまして! I'll help you open your first repository.
+          {:else if setupWizardCtrl.step === "pick"}
+            Choose the folder that has the repository you want to work in.
+          {:else if setupWizardCtrl.step === "identity"}
+            This repository has no commit identity yet — I can set one just for it.
+          {:else}
+            All set — ready to open the graph.
+          {/if}
+        </p>
+      </div>
+    </div>
+
+    <div class="msteps" id="setupWizardSteps">
+      {#each STEP_ORDER as _s, i}
+        <span class="s" class:done={i < stepIndex()} class:now={i === stepIndex()}></span>
+      {/each}
+    </div>
+
+    <div class="modal-body">
+      {#if setupWizardCtrl.step === "welcome"}
+        <p class="mut">Three quick steps: pick a repository, confirm who you are (only for that repo), then jump into the graph.</p>
+      {:else if setupWizardCtrl.step === "pick"}
+        {#if setupWizardCtrl.repoPath}
+          <div class="pl-kv"><div><span class="mut">selected</span> <span class="mono">{setupWizardCtrl.repoPath}</span></div></div>
+        {/if}
+        {#if setupWizardCtrl.pathError}
+          <div class="pl-err" style="margin-top:10px">{setupWizardCtrl.pathError}</div>
+        {/if}
+      {:else if setupWizardCtrl.step === "identity"}
+        <div class="confirm-type">
+          <label for="swName">Name</label>
+          <input id="swName" autocomplete="off" spellcheck="false" bind:value={setupWizardCtrl.nameInput} />
+          <label for="swEmail" style="margin-top:8px">Email</label>
+          <input id="swEmail" autocomplete="off" spellcheck="false" bind:value={setupWizardCtrl.emailInput} />
+        </div>
+        <p class="hero-hint">Written only to this repository's <code>.git/config</code> — your global git identity is never touched.</p>
+        {#if setupWizardCtrl.saveError}
+          <div class="pl-err">{setupWizardCtrl.saveError}</div>
+        {/if}
+      {:else if setupWizardCtrl.step === "done"}
+        {#if setupWizardCtrl.identity?.configured}
+          <div class="backup-note">Identity: <span class="mono">{setupWizardCtrl.identity.name} &lt;{setupWizardCtrl.identity.email}&gt;</span></div>
+        {:else}
+          <p class="mut">No identity set — you can add one later with <code>git config user.name</code>/<code>user.email</code>.</p>
+        {/if}
+      {/if}
+    </div>
+
+    <div class="modal-foot">
+      {#if setupWizardCtrl.step === "welcome"}
+        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip</button>
+        <button class="btn" onclick={() => setupWizardCtrl.toPick()}>Get started</button>
+      {:else if setupWizardCtrl.step === "pick"}
+        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip</button>
+        <button class="btn ghost" onclick={() => setupWizardCtrl.backToWelcome()}>Back</button>
+        <button class="btn" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.pickDirectory()}>Choose folder&#8230;</button>
+      {:else if setupWizardCtrl.step === "identity"}
+        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip setup</button>
+        <button class="btn ghost" onclick={() => setupWizardCtrl.backToPick()}>Back</button>
+        <button class="btn ghost" onclick={() => setupWizardCtrl.skipIdentity()}>Not now</button>
+        <button class="btn" disabled={!setupWizardCtrl.canSave} onclick={() => setupWizardCtrl.saveIdentity()}>Save &amp; continue</button>
+      {:else if setupWizardCtrl.step === "done"}
+        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip</button>
+        <button class="btn" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.finish()}>Open repository &#8594;</button>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/islands/setupwizard/SetupWizard.svelte
+++ b/src/islands/setupwizard/SetupWizard.svelte
@@ -87,16 +87,16 @@
         <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip</button>
         <button class="btn" onclick={() => setupWizardCtrl.toPick()}>Get started</button>
       {:else if setupWizardCtrl.step === "pick"}
-        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip</button>
-        <button class="btn ghost" onclick={() => setupWizardCtrl.backToWelcome()}>Back</button>
+        <button class="btn ghost" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.skip()}>Skip</button>
+        <button class="btn ghost" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.backToWelcome()}>Back</button>
         <button class="btn" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.pickDirectory()}>Choose folder&#8230;</button>
       {:else if setupWizardCtrl.step === "identity"}
-        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip setup</button>
-        <button class="btn ghost" onclick={() => setupWizardCtrl.backToPick()}>Back</button>
-        <button class="btn ghost" onclick={() => setupWizardCtrl.skipIdentity()}>Not now</button>
+        <button class="btn ghost" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.skip()}>Skip setup</button>
+        <button class="btn ghost" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.backToPick()}>Back</button>
+        <button class="btn ghost" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.skipIdentity()}>Not now</button>
         <button class="btn" disabled={!setupWizardCtrl.canSave} onclick={() => setupWizardCtrl.saveIdentity()}>Save &amp; continue</button>
       {:else if setupWizardCtrl.step === "done"}
-        <button class="btn ghost" onclick={() => setupWizardCtrl.skip()}>Skip</button>
+        <button class="btn ghost" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.skip()}>Skip</button>
         <button class="btn" disabled={setupWizardCtrl.busy} onclick={() => setupWizardCtrl.finish()}>Open repository &#8594;</button>
       {/if}
     </div>

--- a/src/islands/setupwizard/SetupWizard.svelte
+++ b/src/islands/setupwizard/SetupWizard.svelte
@@ -76,6 +76,9 @@
         {:else}
           <p class="mut">No identity set — you can add one later with <code>git config user.name</code>/<code>user.email</code>.</p>
         {/if}
+        {#if setupWizardCtrl.finishError}
+          <div class="pl-err" style="margin-top:10px">{setupWizardCtrl.finishError}</div>
+        {/if}
       {/if}
     </div>
 

--- a/src/islands/setupwizard/setupwizard.svelte.ts
+++ b/src/islands/setupwizard/setupwizard.svelte.ts
@@ -37,6 +37,9 @@ class SetupWizardState {
   emailInput = $state("");
   saveError = $state("");
 
+  // ── done step ───────────────────────────────────────────────────────────
+  finishError = $state("");
+
   get canSave(): boolean {
     return this.nameInput.trim().length > 0 && this.emailInput.trim().length > 0 && !this.busy;
   }
@@ -124,6 +127,14 @@ class SetupWizardState {
         this.saveError = "";
         this.step = "identity";
       }
+    } catch (e) {
+      // getGitIdentity's binding RETHROWS when TAURI_INVOKE rejects with an
+      // Error (only the non-Error path becomes a {status:"error"} Result), so
+      // without this catch the failure would escape validate() -> pickDirectory()
+      // as an unhandled rejection, leaving the user stranded on "pick" with no
+      // message. Surface it as pathError like every other pick-step failure.
+      this.identity = null;
+      this.pathError = "That doesn't look like a git repository — " + e;
     } finally {
       this.busy = false;
     }
@@ -163,6 +174,7 @@ class SetupWizardState {
   async finish() {
     if (this.busy || !this.repoPath) return;
     this.busy = true;
+    this.finishError = "";
     this.tamaImg = bridge.TAMA_IMG.happy;
     if (this.demo) {
       // Never call bridge.openRepo in demo mode: there is no real Tauri
@@ -172,8 +184,17 @@ class SetupWizardState {
       this.busy = false;
       return;
     }
-    await bridge.openRepo(this.repoPath); // never throws — see legacy/main.ts
-    this.open = false;
+    // openRepo never throws, but it DOES swallow load_graph failures internally
+    // (only a Tama toast) and now reports success/failure. Only tear down the
+    // done-step overlay when the graph actually loaded; on failure keep it up
+    // with an inline error so the user can retry "Open repository".
+    const ok = await bridge.openRepo(this.repoPath);
+    if (ok) {
+      this.open = false;
+    } else {
+      this.tamaImg = bridge.TAMA_IMG.hero;
+      this.finishError = "Couldn't open the repository — please try again.";
+    }
     this.busy = false;
   }
 
@@ -190,6 +211,7 @@ class SetupWizardState {
     this.nameInput = "";
     this.emailInput = "";
     this.saveError = "";
+    this.finishError = "";
     this.busy = false;
     this.open = false;
   }

--- a/src/islands/setupwizard/setupwizard.svelte.ts
+++ b/src/islands/setupwizard/setupwizard.svelte.ts
@@ -66,10 +66,12 @@ class SetupWizardState {
   }
 
   backToWelcome() {
+    if (this.busy) return; // don't jump steps under an in-flight validate/save/open
     this.step = "welcome";
   }
 
   backToPick() {
+    if (this.busy) return; // don't jump steps under an in-flight validate/save/open
     this.identity = null;
     this.step = "pick";
   }
@@ -141,6 +143,7 @@ class SetupWizardState {
   }
 
   skipIdentity() {
+    if (this.busy) return; // don't jump to done under an in-flight saveIdentity
     this.step = "done";
   }
 
@@ -200,6 +203,10 @@ class SetupWizardState {
 
   // ── skippable at any step ────────────────────────────────────────────────
   skip() {
+    // Honor the re-entrancy lock like the Escape handler: dismissing mid-flight
+    // would let a resolving validate()/openRepo() reopen or jump the wizard
+    // after the user already chose to leave.
+    if (this.busy) return;
     this.resetWizard();
   }
 

--- a/src/islands/setupwizard/setupwizard.svelte.ts
+++ b/src/islands/setupwizard/setupwizard.svelte.ts
@@ -1,0 +1,198 @@
+// Setup wizard — controller (Svelte 5 runes singleton).
+//
+// First-run onboarding: welcome -> pick a repository -> check/fix its git
+// identity (repo-local only, never global) -> hand off into the real graph
+// view. Purely an ADDITIVE overlay: it never touches legacy/main.ts's
+// bootEmpty()/pickRepo() hero card, so dismissing the wizard (Esc or any
+// "Skip" button) always falls back to that untouched, already-working path.
+// Same real/demo duality as every other island (filterrepo, bisect, rerere):
+// legacy/main.ts's caller (via main.ts, see there) decides start() vs.
+// openDemo() based on IN_TAURI — this controller never imports ipc/env.
+
+import { commands } from "../../ipc/bindings";
+import * as bridge from "../../legacy/bridge";
+import type { GitIdentity } from "../../ipc/bindings";
+
+export type SetupWizardStep = "welcome" | "pick" | "identity" | "done";
+
+// Canned data for design-mode (!IN_TAURI), same spirit as every other
+// island's DEMO_* constants, so the browser preview still demos the full flow.
+const DEMO_PATH = "/home/demo/my-project";
+const DEMO_IDENTITY: GitIdentity = { name: null, email: null, configured: false };
+
+class SetupWizardState {
+  open = $state(false);
+  busy = $state(false); // re-entrancy lock (dialog / IPC in flight)
+  demo = $state(false);
+  step = $state<SetupWizardStep>("welcome");
+  tamaImg = $state("");
+
+  // ── pick step ──────────────────────────────────────────────────────────
+  repoPath = $state<string | null>(null);
+  pathError = $state("");
+
+  // ── identity step ──────────────────────────────────────────────────────
+  identity = $state<GitIdentity | null>(null);
+  nameInput = $state("");
+  emailInput = $state("");
+  saveError = $state("");
+
+  get canSave(): boolean {
+    return this.nameInput.trim().length > 0 && this.emailInput.trim().length > 0 && !this.busy;
+  }
+
+  // ── real entry — main.ts calls this at boot when IN_TAURI && no repo open ──
+  start() {
+    this.resetWizard();
+    this.demo = false;
+    this.tamaImg = bridge.TAMA_IMG.hero;
+    this.open = true;
+  }
+
+  // ── design-mode demo entry — main.ts calls this when !IN_TAURI ──────────
+  openDemo() {
+    this.resetWizard();
+    this.demo = true;
+    this.tamaImg = bridge.TAMA_IMG.hero;
+    this.open = true;
+  }
+
+  toPick() {
+    this.pathError = "";
+    this.step = "pick";
+  }
+
+  backToWelcome() {
+    this.step = "welcome";
+  }
+
+  backToPick() {
+    this.identity = null;
+    this.step = "pick";
+  }
+
+  async pickDirectory() {
+    if (this.busy) return;
+    this.pathError = "";
+
+    if (this.demo) {
+      this.repoPath = DEMO_PATH;
+      await this.validate();
+      return;
+    }
+
+    let dir: unknown = null;
+    try {
+      const w = window as unknown as { __TAURI__?: any };
+      const d = w.__TAURI__?.dialog;
+      dir = d?.open
+        ? await d.open({ directory: true, title: "Open a Git repository" })
+        : await w.__TAURI__.core.invoke("plugin:dialog|open", {
+            options: { directory: true, title: "Open a Git repository" },
+          });
+    } catch (e) {
+      this.pathError = "Dialog error — " + e;
+      return;
+    }
+    if (!dir) return; // user cancelled the native picker — stay on "pick"
+    this.repoPath = typeof dir === "string" ? dir : (dir as any).path || String(dir);
+    await this.validate();
+  }
+
+  private async validate() {
+    if (!this.repoPath) return;
+    this.busy = true;
+    this.pathError = "";
+    try {
+      if (this.demo) {
+        this.identity = { ...DEMO_IDENTITY };
+      } else {
+        const r = await commands.getGitIdentity(this.repoPath);
+        if (r.status === "ok") {
+          this.identity = r.data;
+        } else {
+          this.identity = null;
+          this.pathError = String(r.error ?? "That doesn't look like a git repository.");
+          return;
+        }
+      }
+      if (this.identity.configured) {
+        this.step = "done";
+      } else {
+        this.nameInput = this.identity.name ?? "";
+        this.emailInput = this.identity.email ?? "";
+        this.saveError = "";
+        this.step = "identity";
+      }
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  skipIdentity() {
+    this.step = "done";
+  }
+
+  async saveIdentity() {
+    if (!this.canSave || !this.repoPath) return;
+    this.busy = true;
+    this.saveError = "";
+    try {
+      const name = this.nameInput.trim();
+      const email = this.emailInput.trim();
+      if (this.demo) {
+        this.identity = { name, email, configured: true };
+        this.step = "done";
+        return;
+      }
+      const res = await commands.setGitIdentity(this.repoPath, name, email);
+      if (res.ok) {
+        this.identity = { name, email, configured: true };
+        this.step = "done";
+      } else {
+        this.saveError = res.message || "Could not set the repository identity.";
+      }
+    } catch (e) {
+      this.saveError = "Could not set the repository identity — " + e;
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  // ── done -> hand off into the real graph view ───────────────────────────
+  async finish() {
+    if (this.busy || !this.repoPath) return;
+    this.busy = true;
+    this.tamaImg = bridge.TAMA_IMG.happy;
+    if (this.demo) {
+      // Never call bridge.openRepo in demo mode: there is no real Tauri
+      // backend to hit, and tinvoke has no IN_TAURI guard of its own.
+      bridge.tama.say("This is where your repository's graph would open. にゃ〜 (demo)", 4200);
+      this.open = false;
+      this.busy = false;
+      return;
+    }
+    await bridge.openRepo(this.repoPath); // never throws — see legacy/main.ts
+    this.open = false;
+    this.busy = false;
+  }
+
+  // ── skippable at any step ────────────────────────────────────────────────
+  skip() {
+    this.resetWizard();
+  }
+
+  private resetWizard() {
+    this.step = "welcome";
+    this.repoPath = null;
+    this.pathError = "";
+    this.identity = null;
+    this.nameInput = "";
+    this.emailInput = "";
+    this.saveError = "";
+    this.busy = false;
+    this.open = false;
+  }
+}
+
+export const setupWizardCtrl = new SetupWizardState();

--- a/src/legacy/bridge.ts
+++ b/src/legacy/bridge.ts
@@ -21,6 +21,11 @@ export {
   demoBisectStatus,
   demoBisectMark,
   renderBisect,
+  // real "open a repository" hand-off (native picker -> load_graph -> render)
+  // — the setup wizard's final step calls this exactly like pickRepo() does.
+  // Safe to live-re-export: a hoisted `function` declaration, not a `const`,
+  // so there's no TDZ risk (see file header).
+  openRepo,
   // the open repo's absolute path (or null when none is open) — a live
   // binding (see the file header): read it as `bridge.CUR_REPO` at call time,
   // never destructure it into a local const, or you'll freeze a stale value.

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -653,6 +653,10 @@ function loadGraph(N){
 /* ============================================================
    12) REAL REPOSITORY (Tauri): open a repo -> Rust load_graph
    ============================================================ */
+// Returns true when the repo actually loaded, false when load_graph (or any
+// step) failed. Never throws — callers that don't care (pickRepo) can ignore
+// the result, while the setup wizard uses it to keep its done-step overlay up
+// so the user can retry "Open repository" instead of being dumped out silently.
 async function openRepo(path){
   try{
     const g = await tinvoke("load_graph", { path });
@@ -670,7 +674,8 @@ async function openRepo(path){
     // last, most relevant thing the user sees — it deliberately overrides the
     // generic greeting rather than racing it.
     await bisectCtrl.probeOnOpen(path);
-  }catch(e){ Tama.warn("Couldn't open that repo — "+e,5000); console.error(e); }
+    return true;
+  }catch(e){ Tama.warn("Couldn't open that repo — "+e,5000); console.error(e); return false; }
 }
 async function reloadGraph(preserveRow){
   if(!IN_TAURI||!CUR_REPO) return;

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -1200,4 +1200,5 @@ function requestRedraw(){ dirty=true; }
 function focusBisectCurrent(){ if(bisect.cur!=null){ select(bisect.cur); state.scrollTarget=clampScroll(bisect.cur*layout.rowH-view.cssH/2); dirty=true; } }
 function clearBisectMarks(){ bisect.good=bisect.bad=null; bisect.cur=null; bisect.skips.clear(); renderBisect(); dirty=true; }
 export { reloadGraph, cheer, highlight, Tama, TAMA_IMG, requestRedraw,
-  syncBisectMarks, focusBisectCurrent, clearBisectMarks, demoBisectStatus, demoBisectMark, renderBisect };
+  syncBisectMarks, focusBisectCurrent, clearBisectMarks, demoBisectStatus, demoBisectMark, renderBisect,
+  openRepo };

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,28 @@ import Rerere from "./islands/rerere/Rerere.svelte";
 import { rerereCtrl } from "./islands/rerere/rerere.svelte.ts";
 import Plumbing from "./islands/plumbing/Plumbing.svelte";
 import FilterRepo from "./islands/filterrepo/FilterRepo.svelte";
+import SetupWizard from "./islands/setupwizard/SetupWizard.svelte";
+import { setupWizardCtrl } from "./islands/setupwizard/setupwizard.svelte.ts";
+import { IN_TAURI } from "./ipc/env";
 import * as bridge from "./legacy/bridge";
 
 mount(Resolver, { target: document.body });
 mount(Bisect, { target: document.body });
 mount(FilterRepo, { target: document.body });
+mount(SetupWizard, { target: document.body });
+
+// Setup wizard: auto-opens once at boot, ON TOP of the untouched bootEmpty()
+// hero card (real app, no repo open yet) or the synthetic demo graph (browser
+// design mode) — see setupwizard.svelte.ts's header for why Esc/"Skip" simply
+// reveals what's already underneath rather than falling back to anything
+// special-cased here. Reading bridge.CUR_REPO here (not destructured) is safe
+// because legacy/main.ts's top-level bootEmpty() has already run to completion
+// by this point (module evaluation order).
+if (IN_TAURI) {
+  if (!bridge.CUR_REPO) setupWizardCtrl.start();
+} else {
+  setupWizardCtrl.openDemo();
+}
 
 // Drawer-PANE islands (not modals): mounted straight into their own pane so
 // the existing .pane/.pane.on show/hide + drawer-tabs wiring in legacy/main.ts


### PR DESCRIPTION
First-run onboarding was just a bare "Open a repository" button with no check that the repo had a commit identity configured. New SetupWizard island (mirrors the filter-repo wizard's pattern) walks welcome -> pick repo -> repo-local identity check/fix -> hand off into the graph view. Skippable at every step; the existing hero card stays untouched as the fallback. Identity read/write always passes --local to the git CLI, so it can never touch the user's global git config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces git config writes (repo-local only, tested) and changes first-launch UX; CI trigger change is low risk.
> 
> **Overview**
> Adds a **first-run Setup Wizard** overlay (welcome → pick repo → optional repo-local identity → open graph) that auto-opens at boot when no repo is loaded in Tauri, or as a demo flow in the browser. Every step is skippable; the existing hero card stays the fallback.
> 
> New Rust **`get_git_identity` / `set_git_identity`** commands read and write `user.name` / `user.email` only via **`git config --local`**, with integration tests asserting the host global config is never modified. **`openRepo`** now returns success/failure so the wizard can keep the done step open and allow retry when `load_graph` fails.
> 
> CI **`push`** triggers are limited to **`main`** so open PRs no longer run the full suite twice on every commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0222c9e2b1e630d90b4cf5fcd4315b584e577d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->