### PR TITLE
Add vim-style keyboard navigation (j/k/gg/G/Ctrl-D/Ctrl-U, / search)

### DIFF
--- a/src/islands/cmdk/Cmdk.svelte
+++ b/src/islands/cmdk/Cmdk.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { cmdkCtrl, shortSha, CMD_CAP } from "./cmdk.svelte.ts";
+  import { isTextInputFocused } from "../vimnav/vimnav.svelte.ts";
 
   let inputEl: HTMLInputElement | undefined = $state();
   let listEl: HTMLDivElement | undefined = $state();
@@ -21,6 +22,16 @@
   function onWindowKeydown(e: KeyboardEvent) {
     if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "k") {
       if (!cmdkCtrl.open && document.querySelector(".scrim.on")) return; // don't cover an open confirm dialog
+      e.preventDefault();
+      cmdkCtrl.toggle();
+      return;
+    }
+    // vim-style "/" search — a real typed character elsewhere, so this needs
+    // the text-input guard the metaKey/ctrlKey check above doesn't (nobody
+    // types Ctrl+K into a text field the same way they'd type a bare "/").
+    if (e.key === "/") {
+      if (isTextInputFocused(e.target as Element | null)) return;
+      if (!cmdkCtrl.open && document.querySelector(".scrim.on")) return;
       e.preventDefault();
       cmdkCtrl.toggle();
     }

--- a/src/islands/detail/Detail.svelte
+++ b/src/islands/detail/Detail.svelte
@@ -89,7 +89,7 @@
         <span class="mut mono" style="font-size:11px">{s.files} file{s.files === 1 ? "" : "s"}{s.truncated ? " (capped)" : ""}</span>
       {/if}
     </div>
-    <div class="tree" id="tree">
+    <div class="tree" id="tree" data-vimnav-list>
       {#if detailCtrl.treeLoading}
         <div class="mut" style="padding:6px 4px"><span class="spinner"></span> loading files&#8230;</div>
       {:else if !detailCtrl.tree.files.length && !Object.keys(detailCtrl.tree.dirs).length}

--- a/src/islands/filterrepo/FilterRepo.svelte
+++ b/src/islands/filterrepo/FilterRepo.svelte
@@ -162,7 +162,7 @@
         {:else if filterRepoCtrl.backups.length === 0}
           <div class="mut pl-empty">No backups recorded yet — a backup is created automatically the first time you run filter-repo.</div>
         {:else}
-          <div class="cf-files" id="filterRepoBackupList" class:busy={filterRepoCtrl.restoreBusy}>
+          <div class="cf-files" id="filterRepoBackupList" class:busy={filterRepoCtrl.restoreBusy} data-vimnav-list>
             {#each filterRepoCtrl.backups as b (b.id)}
               <div
                 class="cf-file"

--- a/src/islands/resolver/Resolver.svelte
+++ b/src/islands/resolver/Resolver.svelte
@@ -35,7 +35,7 @@
     </div>
     <div class="modal-body">
       <div class="cf-layout">
-        <div class="cf-files">
+        <div class="cf-files" data-vimnav-list>
           {#each resolver.files as f (f.path)}
             {@const resolved = !resolver.remaining.has(f.path)}
             <div

--- a/src/islands/sidebar/Sidebar.svelte
+++ b/src/islands/sidebar/Sidebar.svelte
@@ -66,7 +66,7 @@
   <span class="mag">&#9906;</span>
   <input id="refFilter" placeholder="Filter refs&#8230;" spellcheck="false" bind:value={sidebarCtrl.filter} />
 </div>
-<div class="ref-scroll" id="refScroll">
+<div class="ref-scroll" id="refScroll" data-vimnav-list>
   <details class="ref-group" open>
     <summary><span class="tw">&#9656;</span>Local<span class="count" id="cntLocal">{sidebarCtrl.locals.length}</span></summary>
     <div class="ref-list" id="refLocal">

--- a/src/islands/vimnav/VimNav.svelte
+++ b/src/islands/vimnav/VimNav.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  // Vim-style navigation — view. Deliberately NO <style> block: reuses the
+  // existing global .scrim/.modal/.modal-head/.modal-body/.modal-foot/.pl-kv
+  // classes, same convention as every other overlay island. This island has
+  // no modal FLOW of its own (unlike FilterRepo/SetupWizard) — the only
+  // visible surface is a "?"-triggered help overlay; everything else is a
+  // silent window-level keydown listener. See vimnav.svelte.ts for why the
+  // whole dispatch decision lives in the controller rather than here.
+  import { vimnavCtrl, handleGlobalKeydown } from "./vimnav.svelte.ts";
+</script>
+
+<svelte:window on:keydown={handleGlobalKeydown} />
+
+<div class="scrim" id="vimNavHelpScrim" class:on={vimnavCtrl.helpOpen}>
+  <div class="modal">
+    <div class="modal-head">
+      <div>
+        <h3>Keyboard shortcuts</h3>
+        <p>Vim-style navigation — always on, and never active while typing into a text field.</p>
+      </div>
+    </div>
+    <div class="modal-body">
+      <div class="pl-kv">
+        <div><span class="mono">j</span> / <span class="mono">k</span> &#8212; move down/up (the commit graph, or whichever list has focus)</div>
+        <div><span class="mono">gg</span> &#8212; jump to the first commit</div>
+        <div><span class="mono">G</span> &#8212; jump to the last commit</div>
+        <div><span class="mono">Ctrl+D</span> / <span class="mono">Ctrl+U</span> &#8212; half-page down/up</div>
+        <div><span class="mono">/</span> &#8212; open search (same as Ctrl/Cmd+K)</div>
+        <div><span class="mono">Enter</span> / <span class="mono">Space</span> &#8212; activate the focused row</div>
+        <div><span class="mono">?</span> &#8212; toggle this help</div>
+      </div>
+    </div>
+    <div class="modal-foot">
+      <button class="btn" onclick={() => vimnavCtrl.closeHelp()}>Close</button>
+    </div>
+  </div>
+</div>

--- a/src/islands/vimnav/vimnav.svelte.test.ts
+++ b/src/islands/vimnav/vimnav.svelte.test.ts
@@ -1,0 +1,201 @@
+// Tests for the vim-nav controller. Same isolation strategy as
+// filterrepo.svelte.test.ts / resolver.svelte.test.ts / bisect.svelte.test.ts:
+// legacy/bridge is mocked so legacy/main.ts (a whole vanilla canvas app that
+// boots on import) is never evaluated. See that file's header comment for
+// the full rationale.
+//
+// Canvas-selection movement (moveCanvasSelection/jumpCanvasSelection/
+// pageCanvasSelection) IS covered here against the mock below, but real
+// canvas/scroll behavior is only truly verified by hand (see the plan's
+// manual verification checklist) — this suite proves the row-index math,
+// not the pixels.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../legacy/bridge", () => {
+  const state = { selectedRow: -1, scrollTarget: 0 };
+  const layout = { rowH: 20 };
+  const view = { cssH: 200 };
+  return {
+    state,
+    layout,
+    view,
+    G: { N: 100 },
+    clampScroll: vi.fn((v: number) => Math.max(0, v)),
+    select: vi.fn((row: number) => {
+      state.selectedRow = row;
+    }),
+  };
+});
+
+import * as bridge from "../../legacy/bridge";
+import {
+  isTextInputFocused,
+  moveDomFocus,
+  moveCanvasSelection,
+  jumpCanvasSelection,
+  pageCanvasSelection,
+  noteGKey,
+  noteNonGKey,
+} from "./vimnav.svelte.ts";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  (bridge.state as any).selectedRow = -1;
+  (bridge.state as any).scrollTarget = 0;
+  noteNonGKey();
+});
+
+describe("isTextInputFocused", () => {
+  it("is true for input/textarea/select/contenteditable, false for a plain element", () => {
+    document.body.innerHTML = `
+      <input id="i" /><textarea id="t"></textarea><select id="s"></select>
+      <div id="ce" contenteditable="true"></div><div id="plain"></div>
+    `;
+    expect(isTextInputFocused(document.getElementById("i"))).toBe(true);
+    expect(isTextInputFocused(document.getElementById("t"))).toBe(true);
+    expect(isTextInputFocused(document.getElementById("s"))).toBe(true);
+    expect(isTextInputFocused(document.getElementById("ce"))).toBe(true);
+    expect(isTextInputFocused(document.getElementById("plain"))).toBe(false);
+  });
+
+  it("is true for an element nested inside a contenteditable ancestor", () => {
+    document.body.innerHTML = `<div contenteditable="true"><span id="inner">x</span></div>`;
+    expect(isTextInputFocused(document.getElementById("inner"))).toBe(true);
+  });
+
+  it("is false for null (nothing focused)", () => {
+    expect(isTextInputFocused(null)).toBe(false);
+  });
+});
+
+describe("moveDomFocus", () => {
+  function setUpList() {
+    document.body.innerHTML = `
+      <div data-vimnav-list>
+        <div id="r0" tabindex="0"></div>
+        <div id="r1" tabindex="0"></div>
+        <div id="r2" tabindex="0"></div>
+      </div>
+    `;
+  }
+
+  it("returns false when nothing is focused inside a vimnav-list", () => {
+    document.body.innerHTML = `<div id="r0" tabindex="0"></div>`;
+    document.getElementById("r0")!.focus();
+    expect(moveDomFocus(1)).toBe(false);
+  });
+
+  it("moves focus to the next row", () => {
+    setUpList();
+    document.getElementById("r0")!.focus();
+    expect(moveDomFocus(1)).toBe(true);
+    expect(document.activeElement?.id).toBe("r1");
+  });
+
+  it("moves focus to the previous row", () => {
+    setUpList();
+    document.getElementById("r2")!.focus();
+    expect(moveDomFocus(-1)).toBe(true);
+    expect(document.activeElement?.id).toBe("r1");
+  });
+
+  it("stops at the last row instead of wrapping", () => {
+    setUpList();
+    document.getElementById("r2")!.focus();
+    expect(moveDomFocus(1)).toBe(true);
+    expect(document.activeElement?.id).toBe("r2");
+  });
+
+  it("stops at the first row instead of wrapping", () => {
+    setUpList();
+    document.getElementById("r0")!.focus();
+    expect(moveDomFocus(-1)).toBe(true);
+    expect(document.activeElement?.id).toBe("r0");
+  });
+
+  it("lands on the first row when the container itself has focus", () => {
+    document.body.innerHTML = `
+      <div data-vimnav-list tabindex="-1" id="container">
+        <div id="r0" tabindex="0"></div>
+        <div id="r1" tabindex="0"></div>
+      </div>
+    `;
+    document.getElementById("container")!.focus();
+    expect(moveDomFocus(1)).toBe(true);
+    expect(document.activeElement?.id).toBe("r0");
+  });
+});
+
+describe("canvas selection movement", () => {
+  it("moveCanvasSelection starts at row 0 going forward with nothing selected", () => {
+    moveCanvasSelection(1);
+    expect(bridge.state.selectedRow).toBe(0);
+  });
+
+  it("moveCanvasSelection starts at the last row going backward with nothing selected", () => {
+    moveCanvasSelection(-1);
+    expect(bridge.state.selectedRow).toBe(99);
+  });
+
+  it("moveCanvasSelection steps by one and clamps at the bounds", () => {
+    (bridge.state as any).selectedRow = 5;
+    moveCanvasSelection(1);
+    expect(bridge.state.selectedRow).toBe(6);
+
+    (bridge.state as any).selectedRow = 0;
+    moveCanvasSelection(-1);
+    expect(bridge.state.selectedRow).toBe(0);
+
+    (bridge.state as any).selectedRow = 99;
+    moveCanvasSelection(1);
+    expect(bridge.state.selectedRow).toBe(99);
+  });
+
+  it("jumpCanvasSelection jumps to the first/last row", () => {
+    jumpCanvasSelection("first");
+    expect(bridge.state.selectedRow).toBe(0);
+    jumpCanvasSelection("last");
+    expect(bridge.state.selectedRow).toBe(99);
+  });
+
+  it("pageCanvasSelection moves by roughly half a viewport's rows and clamps", () => {
+    // view.cssH=200, layout.rowH=20 -> half-page = floor((200*0.5)/20) = 5 rows
+    (bridge.state as any).selectedRow = 10;
+    pageCanvasSelection(1);
+    expect(bridge.state.selectedRow).toBe(15);
+    pageCanvasSelection(-1);
+    expect(bridge.state.selectedRow).toBe(10);
+
+    (bridge.state as any).selectedRow = 97;
+    pageCanvasSelection(1);
+    expect(bridge.state.selectedRow).toBe(99);
+  });
+});
+
+describe("gg chord detection", () => {
+  it("does not fire on the first g", () => {
+    expect(noteGKey(1000)).toBe(false);
+  });
+
+  it("fires when a second g arrives within the timeout", () => {
+    noteGKey(1000);
+    expect(noteGKey(1300)).toBe(true);
+  });
+
+  it("does not fire when the second g arrives after the timeout", () => {
+    noteGKey(1000);
+    expect(noteGKey(2000)).toBe(false);
+  });
+
+  it("resets after firing so a third g starts a fresh chord", () => {
+    noteGKey(1000);
+    expect(noteGKey(1200)).toBe(true);
+    expect(noteGKey(1250)).toBe(false);
+  });
+
+  it("noteNonGKey clears a pending chord", () => {
+    noteGKey(1000);
+    noteNonGKey();
+    expect(noteGKey(1100)).toBe(false); // treated as a fresh first "g", not a completion
+  });
+});

--- a/src/islands/vimnav/vimnav.svelte.ts
+++ b/src/islands/vimnav/vimnav.svelte.ts
@@ -1,0 +1,191 @@
+// Vim-style keyboard navigation — controller (Svelte 5 runes singleton).
+//
+// Two complementary mechanisms, no bespoke per-surface state needed except
+// for the canvas:
+//   1. Canvas commit graph: j/k actually MOVE state.selectedRow (auto-
+//      scrolling to keep it visible) — today's Arrow keys only scroll (see
+//      legacy/main.ts's cv keydown handler), they're left untouched. gg/G
+//      jump to the first/last commit; Ctrl-D/Ctrl-U move by roughly half a
+//      viewport's worth of rows.
+//   2. Generic DOM-list traversal: when focus is on a [tabindex="0"] row
+//      inside a [data-vimnav-list] container (sidebar ref rows, the
+//      filter-repo restore-backup list, the conflict resolver's file list,
+//      the detail panel's file tree), j/k moves focus to the next/previous
+//      such row. Every one of those rows ALREADY has its own Enter/Space
+//      handler wired (checkout, select backup, select file, …) — this is
+//      purely a focus-mover, it adds no new activation logic anywhere.
+//
+// Always-on, no setting: nothing in GitCat's existing keybinding catalog
+// conflicts with h/j/k/l/g/G/Ctrl-D/Ctrl-U//, and both gitui and tig (the
+// tools this feature is modeled on) ship vim-nav on by default. "?" toggles
+// a minimal help overlay so the feature is still discoverable.
+//
+// This island never imports ipc/env — like every other controller, the
+// real/demo decision belongs to main.ts, not here (this feature has no
+// demo-mode branch at all: it's pure keyboard plumbing, identical in both).
+
+import * as bridge from "../../legacy/bridge";
+
+// ── text-input guard ────────────────────────────────────────────────────
+// The one existing precedent for this anywhere in the codebase is
+// legacy/main.ts's Cmd/Ctrl+Z handler (`!e.target.closest("input,textarea,
+// [contenteditable=true]")`) — extended here to also exclude `select`,
+// since Sidebar.svelte's branch-from dropdown wasn't covered by the
+// original and would otherwise have "j"/"k" hijacked while open.
+export function isTextInputFocused(el: Element | null): boolean {
+  return !!el?.closest("input, textarea, select, [contenteditable=true]");
+}
+
+// ── generic DOM-list focus traversal ────────────────────────────────────
+// Never wraps (stops at the first/last row) — matches how a real cursor
+// doesn't wrap in tig/gitui. Returns whether a [data-vimnav-list] container
+// was found at all, so the caller knows whether to fall back to moving the
+// canvas selection instead.
+export function moveDomFocus(dir: 1 | -1): boolean {
+  const active = document.activeElement;
+  if (!active) return false;
+  const container = active.closest("[data-vimnav-list]");
+  if (!container) return false;
+  const rows = Array.from(container.querySelectorAll<HTMLElement>('[tabindex="0"]'));
+  if (!rows.length) return true;
+  const idx = rows.indexOf(active as HTMLElement);
+  if (idx < 0) {
+    // Focus is inside the container but not itself on a navigable row (e.g.
+    // the container itself has focus) — land on the first/last row.
+    rows[dir > 0 ? 0 : rows.length - 1].focus();
+    return true;
+  }
+  const next = idx + dir;
+  if (next >= 0 && next < rows.length) rows[next].focus();
+  return true;
+}
+
+// ── canvas commit-graph selection ───────────────────────────────────────
+// scrollRowIntoView mirrors the one formula cmdk.svelte.ts's jump()/
+// bisectdrawer.svelte.ts's focusBisectCurrent()/legacy main.ts's
+// reloadGraph() each independently duplicate — factored into one place
+// here rather than a fourth copy.
+function scrollRowIntoView(row: number) {
+  bridge.state.scrollTarget = bridge.clampScroll(row * bridge.layout.rowH - bridge.view.cssH * 0.4);
+}
+
+export function moveCanvasSelection(dir: 1 | -1) {
+  const n: number = bridge.G?.N ?? 0;
+  if (!n) return;
+  const cur: number = bridge.state.selectedRow;
+  const next = cur < 0 ? (dir > 0 ? 0 : n - 1) : Math.max(0, Math.min(n - 1, cur + dir));
+  bridge.select(next);
+  scrollRowIntoView(next);
+}
+
+export function jumpCanvasSelection(pos: "first" | "last") {
+  const n: number = bridge.G?.N ?? 0;
+  if (!n) return;
+  const row = pos === "first" ? 0 : n - 1;
+  bridge.select(row);
+  scrollRowIntoView(row);
+}
+
+export function pageCanvasSelection(dir: 1 | -1) {
+  const n: number = bridge.G?.N ?? 0;
+  if (!n) return;
+  const rowH = bridge.layout.rowH || 1;
+  const rowsPerHalfPage = Math.max(1, Math.floor((bridge.view.cssH * 0.5) / rowH));
+  const cur: number = bridge.state.selectedRow < 0 ? 0 : bridge.state.selectedRow;
+  const next = Math.max(0, Math.min(n - 1, cur + dir * rowsPerHalfPage));
+  bridge.select(next);
+  scrollRowIntoView(next);
+}
+
+// ── "gg" chord detection ─────────────────────────────────────────────────
+// A bare "g" arms a short window; a second "g" within it completes the
+// chord (mirrors vim/tig's gg = jump-to-top). Module-level, not $state:
+// this is never rendered, just a timing latch.
+const GG_TIMEOUT_MS = 600;
+let pendingGAt = 0;
+
+export function noteNonGKey() {
+  pendingGAt = 0;
+}
+
+/** Call on every bare "g" keydown; returns true once the SECOND "g" of a
+ * "gg" chord arrives within GG_TIMEOUT_MS (and resets the pending state). */
+export function noteGKey(now: number = Date.now()): boolean {
+  if (pendingGAt && now - pendingGAt <= GG_TIMEOUT_MS) {
+    pendingGAt = 0;
+    return true;
+  }
+  pendingGAt = now;
+  return false;
+}
+
+function anyOtherScrimOpen(): boolean {
+  return !!document.querySelector(".scrim.on");
+}
+
+// ── help overlay (the only reactive state this island owns) ────────────
+class VimNavState {
+  helpOpen = $state(false);
+
+  toggleHelp() {
+    if (!this.helpOpen && anyOtherScrimOpen()) return; // don't cover another open modal
+    this.helpOpen = !this.helpOpen;
+  }
+  closeHelp() {
+    this.helpOpen = false;
+  }
+}
+export const vimnavCtrl = new VimNavState();
+
+// ── the single global dispatch entry point (view wires this to keydown) ─
+// "/" is deliberately NOT handled here — Cmdk.svelte's own onWindowKeydown
+// owns it (opens the same palette as Ctrl/Cmd+K), guarded by
+// isTextInputFocused the same way, so there's exactly one place that binding
+// lives rather than two competing handlers.
+export function handleGlobalKeydown(e: KeyboardEvent) {
+  if (isTextInputFocused(e.target as Element | null)) return;
+
+  if (e.key === "Escape") {
+    if (vimnavCtrl.helpOpen) {
+      e.preventDefault();
+      vimnavCtrl.closeHelp();
+    }
+    return;
+  }
+  if (e.key === "?") {
+    e.preventDefault();
+    vimnavCtrl.toggleHelp();
+    return;
+  }
+  if (vimnavCtrl.helpOpen) return; // don't act on nav keys while help is up
+
+  if (e.key === "j" || e.key === "k") {
+    e.preventDefault();
+    const dir = e.key === "j" ? 1 : -1;
+    noteNonGKey();
+    if (moveDomFocus(dir)) return;
+    if (!anyOtherScrimOpen()) moveCanvasSelection(dir);
+    return;
+  }
+  if (e.key === "g") {
+    const completed = noteGKey();
+    if (completed) {
+      e.preventDefault();
+      if (!anyOtherScrimOpen()) jumpCanvasSelection("first");
+    }
+    return;
+  }
+  if (e.key === "G") {
+    noteNonGKey();
+    e.preventDefault();
+    if (!anyOtherScrimOpen()) jumpCanvasSelection("last");
+    return;
+  }
+  if ((e.ctrlKey || e.metaKey) && (e.key === "d" || e.key === "u")) {
+    noteNonGKey();
+    e.preventDefault();
+    if (!anyOtherScrimOpen()) pageCanvasSelection(e.key === "d" ? 1 : -1);
+    return;
+  }
+  noteNonGKey();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import SetupWizard from "./islands/setupwizard/SetupWizard.svelte";
 import { setupWizardCtrl } from "./islands/setupwizard/setupwizard.svelte.ts";
 import Cmdk from "./islands/cmdk/Cmdk.svelte";
 import { cmdkCtrl } from "./islands/cmdk/cmdk.svelte.ts";
+import VimNav from "./islands/vimnav/VimNav.svelte";
 import Detail from "./islands/detail/Detail.svelte";
 import BisectDrawer from "./islands/bisectdrawer/BisectDrawer.svelte";
 import Sidebar from "./islands/sidebar/Sidebar.svelte";
@@ -44,6 +45,7 @@ if (IN_TAURI) {
 }
 
 mount(Cmdk, { target: document.body });
+mount(VimNav, { target: document.body });
 mount(Detail, { target: document.getElementById("detail")! });
 mount(BisectDrawer, { target: document.getElementById("pane-bisect")! });
 


### PR DESCRIPTION
GitCat was mouse-first: the canvas's arrow keys only scrolled (never changed selection), and every list (sidebar branches, backup list, conflict files, file tree) had no keyboard cursor beyond native Tab order. Modeled on gitui/tig's vim-flavored (not full modal) navigation.

j/k move the canvas selection (auto-scrolling into view) or, when focus is already inside one of the four existing list surfaces, move DOM focus through it instead - reusing each row's already-wired Enter/Space activation untouched. gg/G jump to the first/last commit, Ctrl-D/Ctrl-U half-page. / opens the existing command palette. ? toggles a minimal help overlay for discoverability.

Always-on, no setting: nothing in the existing keybinding catalog conflicts, and neither gitui nor tig gate this behind an opt-in. A shared text-input guard (extending the one existing precedent, the Cmd/Ctrl+Z handler) ensures none of this fires while typing into a real input/textarea/select/contenteditable.