### PR TITLE
Add animated About panel, replacing the native OS About dialog

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,12 +3,43 @@
 use std::time::Instant;
 
 use git2::{Delta, DiffFindOptions, DiffOptions, Patch};
+use serde::Serialize;
 
 use crate::git_read::read_repo;
 use crate::layout::{layout, NCOL};
 use crate::model::{
     CommitDetail, CommitMeta, DiffHunkRow, DiffLineRow, FileChange, GraphData, Person,
 };
+
+/// Static app metadata for the custom About panel — the same `PackageInfo`
+/// fields `menu.rs`'s native-About builder reads, just reshaped as a plain
+/// serializable struct instead of Tauri's menu-only `AboutMetadata` type.
+#[derive(Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AppInfo {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub authors: Vec<String>,
+    pub copyright: String,
+    pub website: String,
+}
+
+/// JS: `commands.getAppInfo()`. No repo/path needed — this is pure static
+/// build-time metadata (Cargo.toml's `[package]` table), never `Err`.
+#[tauri::command]
+#[specta::specta]
+pub fn get_app_info(app: tauri::AppHandle<tauri::Wry>) -> AppInfo {
+    let pkg = app.package_info();
+    AppInfo {
+        name: pkg.name.clone(),
+        version: pkg.version.to_string(),
+        description: pkg.description.to_string(),
+        authors: pkg.authors.split(':').map(|s| s.trim().to_string()).collect(),
+        copyright: "\u{a9} Jiucheng Zang".to_string(),
+        website: "https://github.com/zangjiucheng/GitCat".to_string(),
+    }
+}
 
 /// Caps so a monster commit (vendored dir, generated lockfile) can't stall the
 /// UI or blow up the payload. Beyond these we flag truncation and stop.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ pub mod git_merge; // M6 (stage 1): merge (drag-onto-HEAD) + continue / abort
 pub mod git_rebase; // M6 (stage 2): linear rebase onto a target + continue / skip / abort
 pub mod identity; // Setup wizard: repo-local git identity (user.name/user.email) check + fix
 pub mod layout;
-pub mod menu; // native app menu (File/Edit/View/Window/Help) + About panel
+pub mod menu; // native app menu (File/Edit/View/Window/Help)
 pub mod model;
 pub mod plumbing; // M5b: read-only object-database inspector (commit/tree/blob/tag by rev)
 pub mod reflog; // M4: reflog rescue (read HEAD reflog + restore to a historical entry)
@@ -28,6 +28,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
     Builder::<tauri::Wry>::new().commands(collect_commands![
         commands::load_graph,
         commands::commit_detail,
+        commands::get_app_info,
         // Safety Manager (snapshot / list / global undo)
         safety::create_snapshot,
         safety::list_snapshots,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,17 +1,22 @@
-// Native application menu — the "系统 menu" (system menu) + About panel.
+// Native application menu — the "系统 menu" (system menu).
 //
 // Two kinds of items:
-//  - predefined (About, Cut/Copy/Paste/Select All, Minimize, Close Window,
-//    Quit, and on macOS Services/Hide/Hide Others/Show All): handled entirely
-//    by the OS/webview, no event ever reaches Rust. These aren't just
-//    decorative — without an Edit menu wiring Cut/Copy/Paste/Select All,
-//    those shortcuts don't work at all in a Tauri webview's text inputs.
+//  - predefined (Cut/Copy/Paste/Select All, Minimize, Close Window, Quit, and
+//    on macOS Services/Hide/Hide Others/Show All): handled entirely by the
+//    OS/webview, no event ever reaches Rust. These aren't just decorative —
+//    without an Edit menu wiring Cut/Copy/Paste/Select All, those shortcuts
+//    don't work at all in a Tauri webview's text inputs.
 //  - custom (Open Repository…, New Branch…, Fetch/Pull/Push, Toggle Theme,
-//    Command Palette, the two Help links): fire a MenuEvent caught in
+//    Command Palette, About, the two Help links): fire a MenuEvent caught in
 //    handle_event() below. The two Help links (GitHub / Report an Issue) are
 //    handled entirely in Rust via the opener plugin; the rest need the
 //    frontend (they're Svelte controller / legacy chrome calls), so they're
 //    forwarded as a "menu-action" JS event — see the listener in src/main.ts.
+//
+// About is deliberately a CUSTOM item, not the native `.about()` menu-builder
+// panel: the OS-rendered About dialog can't be animated or restyled at all,
+// so it's replaced with an in-app modal (see src/islands/about) that reads
+// the same package metadata via the `get_app_info` command instead.
 //
 // Deliberately NOT included: Undo/Redo. The app already binds ⌘Z to its own
 // global Safety-Manager undo (see globalUndo() in legacy/main.ts) — adding a
@@ -19,7 +24,7 @@
 // (or instead of) the existing JS keydown listener, which would be a strictly
 // worse outcome than just not having the item.
 use tauri::{
-    menu::{AboutMetadataBuilder, Menu, MenuBuilder, MenuEvent, MenuItemBuilder, SubmenuBuilder},
+    menu::{Menu, MenuBuilder, MenuEvent, MenuItemBuilder, SubmenuBuilder},
     AppHandle, Emitter, Wry,
 };
 use tauri_plugin_opener::OpenerExt;
@@ -28,22 +33,11 @@ const REPO_URL: &str = "https://github.com/zangjiucheng/GitCat";
 const ISSUES_URL: &str = "https://github.com/zangjiucheng/GitCat/issues/new";
 
 pub fn build(app: &AppHandle<Wry>) -> tauri::Result<Menu<Wry>> {
-    let pkg = app.package_info();
-    let about = AboutMetadataBuilder::new()
-        .name(Some(pkg.name.clone()))
-        .version(Some(pkg.version.to_string()))
-        .authors(Some(pkg.authors.split(':').map(|s| s.trim().to_string()).collect()))
-        .comments(Some(pkg.description.to_string()))
-        .copyright(Some("\u{a9} Jiucheng Zang".to_string()))
-        .website(Some(REPO_URL.to_string()))
-        .website_label(Some("GitHub".to_string()))
-        .build();
+    let about_item = MenuItemBuilder::with_id("about", "About GitCat").build(app)?;
 
-    // `about` is moved into whichever ONE of these two cfg-gated branches
-    // actually exists for the target platform — never both in the same build.
     #[cfg(target_os = "macos")]
-    let app_menu = SubmenuBuilder::new(app, &pkg.name)
-        .about(Some(about))
+    let app_menu = SubmenuBuilder::new(app, &app.package_info().name)
+        .item(&about_item)
         .separator()
         .services()
         .separator()
@@ -102,7 +96,7 @@ pub fn build(app: &AppHandle<Wry>) -> tauri::Result<Menu<Wry>> {
         // macOS already surfaces About in the app menu above; Windows/Linux
         // have no app menu, so Help is the conventional home for it there.
         #[cfg(not(target_os = "macos"))]
-        let b = b.separator().about(Some(about));
+        let b = b.separator().item(&about_item);
         b.build()?
     };
 
@@ -130,7 +124,7 @@ pub fn handle_event(app: &AppHandle<Wry>, event: MenuEvent) {
         // Everything else is a frontend (Svelte controller / legacy chrome)
         // action — forward the id as a JS event rather than duplicating that
         // logic in Rust.
-        id @ ("open-repo" | "new-branch" | "toggle-theme" | "cmdk" | "fetch" | "pull" | "push") => {
+        id @ ("open-repo" | "new-branch" | "toggle-theme" | "cmdk" | "fetch" | "pull" | "push" | "about") => {
             let _ = app.emit("menu-action", id);
         }
         _ => {}

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -30,6 +30,13 @@ async commitDetail(path: string, sha: string) : Promise<Result<CommitDetail, str
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * JS: `commands.getAppInfo()`. No repo/path needed — this is pure static
+ * build-time metadata (Cargo.toml's `[package]` table), never `Err`.
+ */
+async getAppInfo() : Promise<AppInfo> {
+    return await TAURI_INVOKE("get_app_info");
+},
 async createSnapshot(path: string) : Promise<Result<Snapshot, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_snapshot", { path }) };
@@ -462,6 +469,12 @@ async unwatchRepo() : Promise<void> {
 
 /** user-defined types **/
 
+/**
+ * Static app metadata for the custom About panel — the same `PackageInfo`
+ * fields `menu.rs`'s native-About builder reads, just reshaped as a plain
+ * serializable struct instead of Tauri's menu-only `AboutMetadata` type.
+ */
+export type AppInfo = { name: string; version: string; description: string; authors: string[]; copyright: string; website: string }
 export type BisectStatus = { ok: boolean; inProgress: boolean; current: CommitInfo | null; badRef: string | null; goodRefs: string[]; remainingRevs: number; estSteps: number; firstBad: CommitInfo | null; log: string[]; message: string; backupRef: string | null }
 export type BlobObject = { sha: string; size: number; isBinary: boolean; 
 /**

--- a/src/islands/about/About.svelte
+++ b/src/islands/about/About.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  // About panel — view. Unlike every other overlay island in this app, this
+  // one uses {#if aboutCtrl.open} (mount/unmount) rather than the usual
+  // class:on={ctrl.open} (always-in-DOM, display:none toggle) — deliberately,
+  // so the entrance animation below actually REPLAYS on every open instead
+  // of running once and never again (a CSS `animation` doesn't restart on a
+  // display:none -> flex flip of an ancestor, only on the node's own
+  // creation). Nothing here needs to persist state while closed (aboutCtrl's
+  // `info` cache lives on the controller, not local view state), so
+  // unmounting is free.
+  import { aboutCtrl } from "./about.svelte.ts";
+  import * as bridge from "../../legacy/bridge";
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key !== "Escape" || !aboutCtrl.open) return;
+    aboutCtrl.close();
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+{#if aboutCtrl.open}
+  <div class="scrim on">
+    <div class="modal about-modal">
+      <button class="about-close" aria-label="Close" onclick={() => aboutCtrl.close()}>&#10005;</button>
+
+      <div class="about-tama-wrap">
+        <span class="about-sparkle s1">&#10022;</span>
+        <span class="about-sparkle s2">&#10022;</span>
+        <span class="about-sparkle s3">&#10022;</span>
+        <img class="about-tama" src={bridge.TAMA_IMG.happy} alt="Tama, GitCat's guardian" />
+      </div>
+
+      {#if aboutCtrl.loading}
+        <p class="mut" style="margin-top:14px">loading&#8230;</p>
+      {:else if aboutCtrl.info}
+        {@const info = aboutCtrl.info}
+        <h2 class="about-name">{info.name}</h2>
+        <span class="about-version mono">v{info.version}</span>
+        <p class="about-desc">{info.description}</p>
+
+        <div class="about-meta">
+          <div>{info.authors.join(", ")}</div>
+          <div class="mut">{info.copyright}</div>
+        </div>
+
+        <div class="modal-foot" style="justify-content:center;border-top:none;padding-top:16px">
+          <button class="btn ghost" onclick={() => aboutCtrl.openWebsite()}>&#128279; GitHub</button>
+          <button class="btn" onclick={() => aboutCtrl.close()}>Close</button>
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .about-modal {
+    position: relative;
+    text-align: center;
+    padding: 30px 26px 20px;
+    animation: about-in 0.38s cubic-bezier(0.2, 0.8, 0.2, 1);
+  }
+  @keyframes about-in {
+    from {
+      opacity: 0;
+      transform: translateY(6px) scale(0.97);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .about-close {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    border: none;
+    background: none;
+    color: var(--muted);
+    font-size: 13px;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+  }
+  .about-close:hover {
+    color: var(--text);
+  }
+
+  .about-tama-wrap {
+    position: relative;
+    display: inline-block;
+    margin-bottom: 4px;
+  }
+  .about-tama {
+    /* Source art is 320x429 (portrait) — width-only + height:auto keeps its
+       natural aspect ratio; forcing an explicit height here squashed it. */
+    width: 84px;
+    height: auto;
+    display: block;
+    animation: about-bob 2.6s ease-in-out infinite;
+  }
+  @keyframes about-bob {
+    0%,
+    100% {
+      transform: translateY(0) rotate(0deg);
+    }
+    50% {
+      transform: translateY(-3px) rotate(-1deg);
+    }
+  }
+
+  .about-sparkle {
+    position: absolute;
+    font-size: 13px;
+    color: var(--accent);
+    opacity: 0;
+    animation: about-sparkle 2.6s ease-in-out infinite;
+  }
+  .s1 {
+    top: 2px;
+    left: -6px;
+    animation-delay: 0s;
+  }
+  .s2 {
+    top: 14px;
+    right: -10px;
+    animation-delay: 0.6s;
+  }
+  .s3 {
+    bottom: 8px;
+    left: 2px;
+    animation-delay: 1.3s;
+  }
+  @keyframes about-sparkle {
+    0%,
+    100% {
+      opacity: 0;
+      transform: scale(0.4) rotate(0deg);
+    }
+    50% {
+      opacity: 0.9;
+      transform: scale(1) rotate(45deg);
+    }
+  }
+
+  .about-name {
+    font-family: var(--display);
+    font-size: 22px;
+    margin: 6px 0 0;
+  }
+  .about-version {
+    display: inline-block;
+    font-size: 11px;
+    color: var(--muted);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border-radius: 999px;
+    padding: 2px 9px;
+    margin-top: 6px;
+  }
+  .about-desc {
+    color: var(--muted);
+    font-size: 13px;
+    margin: 12px 0 0;
+    line-height: 1.5;
+  }
+  .about-meta {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--border);
+    font-size: 11.5px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .about-modal,
+    .about-tama,
+    .about-sparkle {
+      animation: none !important;
+    }
+  }
+</style>

--- a/src/islands/about/about.svelte.ts
+++ b/src/islands/about/about.svelte.ts
@@ -1,0 +1,59 @@
+// About panel — controller (Svelte 5 runes singleton).
+//
+// Replaces the native OS "About" menu item (see src-tauri/src/menu.rs's
+// header comment for why) with a small in-app modal that can actually be
+// animated. get_app_info() is pure static build metadata — safe to call
+// with no repo open, never errors in the real app. In browser design-mode
+// (no Tauri backend) the invoke naturally rejects, so show() falls back to
+// canned info instead of needing a separate openDemo() entry point — this
+// panel has no real/demo BEHAVIORAL difference, just a data source.
+
+import { commands } from "../../ipc/bindings";
+import type { AppInfo } from "../../ipc/bindings";
+
+const DEMO_INFO: AppInfo = {
+  name: "GitCat",
+  version: "0.0.0-dev",
+  description: "A git GUI client with a Safety Manager that never lets you lose history.",
+  authors: ["Jiucheng Zang"],
+  copyright: "\u{a9} Jiucheng Zang",
+  website: "https://github.com/zangjiucheng/GitCat",
+};
+
+function openExternal(url: string) {
+  const w = window as unknown as { __TAURI__?: any };
+  if (w.__TAURI__?.opener?.openUrl) {
+    w.__TAURI__.opener.openUrl(url);
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}
+
+class AboutState {
+  open = $state(false);
+  loading = $state(false);
+  info = $state<AppInfo | null>(null);
+
+  async show() {
+    this.open = true;
+    if (this.info) return; // cached from a previous open — static data, never changes
+    this.loading = true;
+    try {
+      this.info = await commands.getAppInfo();
+    } catch {
+      this.info = DEMO_INFO; // no Tauri backend (browser design-mode) — still previewable
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  close() {
+    this.open = false;
+  }
+
+  openWebsite() {
+    if (this.info?.website) openExternal(this.info.website);
+  }
+}
+
+export const aboutCtrl = new AboutState();

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,8 @@ import { setupWizardCtrl } from "./islands/setupwizard/setupwizard.svelte.ts";
 import Cmdk from "./islands/cmdk/Cmdk.svelte";
 import { cmdkCtrl } from "./islands/cmdk/cmdk.svelte.ts";
 import VimNav from "./islands/vimnav/VimNav.svelte";
+import About from "./islands/about/About.svelte";
+import { aboutCtrl } from "./islands/about/about.svelte.ts";
 import Detail from "./islands/detail/Detail.svelte";
 import BisectDrawer from "./islands/bisectdrawer/BisectDrawer.svelte";
 import Sidebar from "./islands/sidebar/Sidebar.svelte";
@@ -46,6 +48,7 @@ if (IN_TAURI) {
 
 mount(Cmdk, { target: document.body });
 mount(VimNav, { target: document.body });
+mount(About, { target: document.body });
 mount(Detail, { target: document.getElementById("detail")! });
 mount(BisectDrawer, { target: document.getElementById("pane-bisect")! });
 
@@ -100,6 +103,9 @@ if (IN_TAURI) {
         break;
       case "push":
         bridge.doPush();
+        break;
+      case "about":
+        aboutCtrl.show();
         break;
     }
   });


### PR DESCRIPTION
The old About was Tauri's native .about() menu item, an OS-rendered dialog that can't be styled or animated at all. Replaced it with a custom in-app modal (src/islands/about) fed by a new get_app_info command that reads the same package metadata the native dialog used.

The modal uses {#if}-based mount/unmount (unlike every other overlay island's always-in-DOM display:none toggle) so its entrance animation actually replays on every open. Tama gets a gentle continuous bob with a few twinkling sparkle accents; both respect prefers-reduced-motion.

menu.rs's native About item is now a plain custom MenuItem firing through the same menu-action pipe as every other item.

Fixed during review: the mascot art is naturally portrait (320x429), but was forced into a 96x96 square, visibly squashing it vertically - switched to width-only sizing with height:auto to preserve its actual aspect ratio.