### PR TITLE
docs: start the user manual (Guide) — core pages + scaffold

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,11 +73,56 @@ export default defineConfig({
     logo: "/gitcat-icon.svg",
     nav: [
       { text: "Home", link: "/" },
+      { text: "Guide", link: "/guide/" },
       { text: "Install", link: "/install" },
       { text: "Features", link: "/features" },
       { text: "Plugins", link: "/plugins" },
       { text: "FAQ", link: "/faq" },
     ],
+
+    // A sidebar only for the /guide/ user manual (the other pages stay
+    // sidebar-less, full-width marketing/reference pages). Grouped to match the
+    // manual's four arcs: get oriented, do everyday work, stay safe, go deeper.
+    sidebar: {
+      "/guide/": [
+        {
+          text: "Getting started",
+          items: [
+            { text: "Overview & layout", link: "/guide/" },
+            { text: "Opening a repository", link: "/guide/opening-a-repository" },
+            { text: "Reading the commit graph", link: "/guide/commit-graph" },
+          ],
+        },
+        {
+          text: "Everyday work",
+          items: [
+            { text: "Committing & staging", link: "/guide/committing" },
+            { text: "Branches & tags", link: "/guide/branches" },
+            { text: "Syncing with remotes", link: "/guide/remotes" },
+            { text: "Cherry-pick, merge & revert", link: "/guide/combining" },
+            { text: "Rebasing", link: "/guide/rebasing" },
+          ],
+        },
+        {
+          text: "Safety & recovery",
+          items: [
+            { text: "Undo & the Safety Manager", link: "/guide/undo-safety" },
+            { text: "History & recovery tools", link: "/guide/history-tools" },
+            { text: "Rewriting history", link: "/guide/rewriting-history" },
+          ],
+        },
+        {
+          text: "Power & customization",
+          items: [
+            { text: "Command palette & keyboard", link: "/guide/keyboard" },
+            { text: "Terminal & external tools", link: "/guide/terminal-tools" },
+            { text: "Tama", link: "/guide/tama" },
+            { text: "Plugins", link: "/guide/plugins" },
+            { text: "Settings", link: "/guide/settings" },
+          ],
+        },
+      ],
+    },
 
     socialLinks: [{ icon: "github", link: "https://github.com/zangjiucheng/GitCat" }],
 

--- a/docs/guide/branches.md
+++ b/docs/guide/branches.md
@@ -1,0 +1,20 @@
+---
+description: Working with branches and tags in GitCat — create, checkout, rename, delete, check out a remote branch, control which branches show on the graph, and manage tags.
+---
+
+# Branches & tags
+
+Managing branches and tags without a terminal — everything here lives in the sidebar and on the graph's ref labels.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers; the [Features](/features) list has the short version in the meantime.
+:::
+
+## What this page will cover
+
+- **Creating a branch** — from `HEAD` or from any local/remote start point you pick (`⌘⇧N`, or **File ▸ New Branch…**).
+- **Checking out** a local branch, or a remote one directly — checking out `origin/feature-x` creates and switches to a local tracking branch automatically.
+- **Rename / delete** — from the right-click menu on a branch or tag label on the graph, or the sidebar branch menu.
+- **Branch visibility** — hide/show individual branches, "Hide all branches", and the **Auto** mode that keeps just the current branch plus anything with unpushed/unmerged work.
+- **Tags** — create, delete, and push tags from the sidebar.
+- How switching branches interacts with uncommitted changes (the dirty-tree chooser — see [Undo & the Safety Manager](/guide/undo-safety)).

--- a/docs/guide/combining.md
+++ b/docs/guide/combining.md
@@ -1,0 +1,19 @@
+---
+description: Cherry-pick, merge, and revert in GitCat — drag-and-drop and right-click, merge strategies, and the 3-way conflict resolver.
+---
+
+# Cherry-pick, merge & revert
+
+Moving commits between branches, combining branches, and undoing a commit — all backed by the same conflict resolver.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers; the [Features](/features) list has the short version in the meantime.
+:::
+
+## What this page will cover
+
+- **Cherry-pick** — **shift-drag** a commit onto `HEAD`, or right-click ▸ Cherry-pick. Optionally record the origin (`-x`).
+- **Merge** — drag a branch onto your current one, or right-click ▸ Merge, with explicit strategy control: **squash**, or a fast-forward choice of **auto** / **no-ff** (always a real merge commit) / **ff-only** (refuses unless a fast-forward is possible).
+- **Revert** — a first-class right-click action, not a workaround.
+- **The 3-way conflict resolver** — when anything (cherry-pick, merge, revert, rebase, patch apply) doesn't apply cleanly, the same resolver opens so you're never left in a broken half-state.
+- Choosing the **mainline parent** when cherry-picking or reverting a merge commit.

--- a/docs/guide/commit-graph.md
+++ b/docs/guide/commit-graph.md
@@ -1,0 +1,63 @@
+---
+description: How to read and navigate GitCat's commit graph — the HEAD marker, dimmed merged commits, ref labels, selecting commits, and moving around by mouse or keyboard.
+---
+
+# Reading the commit graph
+
+The graph is where you'll spend most of your time. It draws your history as a **swimlane graph**: each commit is a dot on a coloured lane, with curved edges connecting parents to children. It's rendered on a fast canvas that stays smooth on repositories with hundreds of thousands of commits — only the rows on screen are ever drawn, and scrolling keeps every commit's text **readable** the whole time.
+
+## What you're looking at
+
+- **The top row is your working directory.** Pinned above all real history is an **Uncommitted changes** row. Select it to open the [working-directory view](/guide/committing) and stage/commit. It shows a badge when you have uncommitted work.
+- **The HEAD marker tells you where you are.** The commit you currently have checked out (`HEAD`) wears a clear "you are here" marker — an accent ring around its dot and a bar down its row. When you've scrolled away and want to get back, press `⌘⇧H` (or the crosshair button in the top bar) to recentre on it.
+- **Dimmed commits are already merged.** Every commit that's already part of your current branch is drawn dimmed, so **unmerged work stands out** — you can see at a glance what's new on a feature branch versus what's already in `main`.
+- **Ref labels live in their own column.** Branch and tag names sit in a dedicated left column rather than cluttering the commit messages. Hover a truncated label to see its full name.
+
+## Selecting a commit
+
+Click any commit row (or move to it with the keyboard) to select it. The **detail panel** then shows everything about that commit:
+
+- the **author** and **committer** split out separately (so you can tell a rebased or cherry-picked commit apart from the original),
+- its **GPG signature** status,
+- a **diffstat** and a **file tree**,
+- and a **syntax-highlighted diff** you can expand to a full-page view for reading a real changeset comfortably.
+
+## Acting on a commit
+
+Two equivalent ways to operate on a commit:
+
+- **Right-click** the commit row for its context menu: **cherry-pick**, **merge**, or **revert** it (among others). See [Cherry-pick, merge & revert](/guide/combining).
+- **Drag and drop** — **shift-drag** a commit onto your current position to cherry-pick it, or drag a branch to merge. When something doesn't apply cleanly, GitCat's 3-way conflict resolver opens instead of leaving you in a broken state.
+
+Right-clicking a **branch or tag label** (rather than a commit) gives a different menu: check it out, rename it, delete it, or check out a remote-tracking branch. See [Branches & tags](/guide/branches).
+
+## Moving around
+
+You can drive the graph entirely from the keyboard:
+
+| Key | Action |
+| --- | --- |
+| `j` / `k` | Move down / up one commit |
+| `gg` / `G` | Jump to the top / bottom of the graph |
+| `Ctrl-D` / `Ctrl-U` | Page down / up |
+| `/` | Search within the graph |
+| `⌘⇧H` | Recentre on `HEAD` |
+| `⌘K` | Open the command palette (jump to any commit, ref, or tool) |
+
+The `⌘K` command palette can also find and show branches that **aren't currently listed in the sidebar** — search for one, pick it, and it appears on the graph.
+
+## When the graph is busy
+
+A few controls (in the [sidebar](/guide/branches) and [Settings](/guide/settings)) help with a crowded history:
+
+- **Branch visibility** — hide or show individual branches, "Hide all branches" to start clean and hand-pick a few, or turn on **Auto** to always show just the current branch plus anything with unpushed or unmerged work.
+- **Ref label priority** — when a commit's labels don't all fit the gutter, Settings lets you choose whether **tags** or **branches** show first; click a row's **+N** chip to cycle the rest into view.
+- **Show all tags** — by default a commit with several tags shows the first; a Settings toggle draws all of them.
+
+## Why it stays fast
+
+You don't need to configure anything, but it's worth knowing: switching branches, creating or deleting a branch or tag, and staging **don't re-walk your whole history** — GitCat recognises the set of commits hasn't changed and updates the refs in place, so a checkout on a huge repo is immediate. Only operations that genuinely add or remove commits (commit, merge, pull) do a full reload.
+
+---
+
+Next: [Committing & staging](/guide/committing).

--- a/docs/guide/committing.md
+++ b/docs/guide/committing.md
@@ -1,0 +1,60 @@
+---
+description: How to stage and commit in GitCat — the working-directory view, hunk- and line-level staging, discarding changes, writing a commit, and stashing.
+---
+
+# Committing & staging
+
+Committing in GitCat happens in the **working-directory view**. Open it by selecting the **Uncommitted changes** row pinned at the top of the graph (or **Tools ▸ Uncommitted Changes**, which jumps straight to it).
+
+This is a real staging view — not a flat list of file paths — split into **Staged** and **Unstaged** changes, with a diff for whatever file you select.
+
+## Staging whole files
+
+Each changed file has a control to move it between unstaged and staged:
+
+- **Stage** a file to include its changes in your next commit.
+- **Unstage** to pull it back out.
+- **Discard** to throw its changes away entirely. Discarding is destructive to that file's uncommitted work, so it's treated as a real action — but committed history is never at risk, and the [Safety Manager](/guide/undo-safety) still has your back for anything that touched history.
+
+## Staging part of a file
+
+Often you only want to commit *some* of the changes in a file. GitCat has a full `git add -p` equivalent built into the diff:
+
+- **By hunk** — each hunk in the diff has its own toolbar to stage, unstage, or discard just that hunk.
+- **By line** — tick individual lines with the per-line checkboxes, then stage, unstage, or discard exactly that selection. **Shift-click** to select a range of lines at once.
+
+This lets you split one messy working file into several clean, focused commits without leaving the app.
+
+## Writing the commit
+
+With the changes you want staged, write your message and commit. A few things worth knowing:
+
+- Your commit is authored with the **git identity** for this repo (see [Opening a repository](/guide/opening-a-repository) to check or change it).
+- The commit is a normal, snapshotted operation — it appears immediately on the graph, and it's covered by [Undo](/guide/undo-safety) like everything else.
+
+## Stashing
+
+When you need to set changes aside without committing them, use **stash**. GitCat supports the operations you actually reach for day to day:
+
+- **Save** the current working changes to a stash,
+- **Apply** a stash (keep it in the list) or **Pop** it (apply and remove),
+- **Drop** a stash you no longer need.
+
+Stashes are listed in the sidebar and stay recoverable, so a "stash → switch branch → come back" flow is safe and visible.
+
+## Reading a file's past while you work
+
+From a file row in the working-directory view (and in a commit's file tree), two per-file tools are one click away:
+
+- **Blame** — a line-by-line annotation of who last changed each line, with an ignore-whitespace toggle, following the file's rename history automatically.
+- **History** — that single file's commit list, rename-following like `git log --follow`.
+
+Both are covered in [History & recovery tools](/guide/history-tools).
+
+## Using your own diff/merge tool
+
+If you'd rather read a change in your own editor, GitCat can hand a file's diff off to a configured **external tool** (VS Code, Beyond Compare, or anything else) instead of the built-in diff. Set one up under [Terminal & external tools](/guide/terminal-tools).
+
+---
+
+Next: [Branches & tags](/guide/branches).

--- a/docs/guide/history-tools.md
+++ b/docs/guide/history-tools.md
@@ -1,0 +1,29 @@
+---
+description: GitCat's investigation and recovery tools — bisect, reflog, rerere, blame, per-file history, author and pickaxe search, and dangling-commit recovery.
+---
+
+# History & recovery tools
+
+The read-only tools for finding things in your history, and the recovery tools for getting things back. Most live under the **Tools** menu and `⌘K`.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers; the [Features](/features) list has the short version in the meantime.
+:::
+
+## What this page will cover
+
+### Finding things
+
+- **Bisect** — mark commits good/bad/skip and watch the candidate range narrow live on the canvas until the first bad commit is found.
+- **Blame** — line-by-line attribution with an ignore-whitespace toggle, rename-following.
+- **Per-file history** — one file's commits with rename-following (`git log --follow`).
+- **Search by author** (`git log --author`) across all history.
+- **Pickaxe / diff-content search** (`git log -S`/`-G`) — every commit whose diff touched a string or pattern. **Search Code** (`⌘F`) and **Search Commit Content** (`⌘⇧F`).
+
+### Getting things back
+
+- **Reflog rescue** — browse every historical `HEAD` position and restore to any of them.
+- **Rerere** — see what git has recorded a conflict resolution for, and toggle `rerere.enabled` without a terminal.
+- **Dangling-object recovery** — `git fsck` finds a commit nothing points to and recovers it as a new branch.
+
+These pair with the [Safety Manager](/guide/undo-safety), which snapshots before every mutation.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,38 @@
+---
+description: The GitCat user manual — how to use the app day to day, from opening a repository to undoing a rebase. Start here for a map of the window and how to get around.
+---
+
+# User manual
+
+Welcome to GitCat. This guide is the practical, task-oriented companion to the [Features](/features) list: instead of "what GitCat can do", it walks through **how you actually do it** — where things live, which button or key does what, and how to get yourself out of trouble when something goes sideways.
+
+If you're brand new, read the three **Getting started** pages in order. If you already know Git and just want to find where an operation lives, jump straight to the section you need from the sidebar.
+
+## The one idea to keep in mind
+
+Everything in GitCat is built around a single promise: **every operation that touches your history is reversible.** Before any mutation — a commit, a merge, a rebase, a reset, even a `filter-repo` run — GitCat pins a snapshot of your repository. That snapshot is what the global **Undo** (`⌘Z` / `Ctrl+Z`) restores from, and the restore is itself just another snapshot, so Undo is always undoable too.
+
+You never have to memorize this or turn anything on. It just means you can explore, drag things around, and try operations you're unsure about, knowing one keystroke takes you back. The [Undo & the Safety Manager](/guide/undo-safety) page covers it in full.
+
+## A map of the window
+
+GitCat is one window with a few fixed regions:
+
+- **The top bar** — the current repository name (click it to switch repos), the branch you're on, and the everyday sync buttons: **Fetch**, **Pull**, **Push**, and **Refresh**. The crosshair button (or `⌘⇧H`) recentres the graph on your current position (`HEAD`), and the theme toggle flips light/dark.
+- **The sidebar** (left) — your branches, remotes, tags, and **Snapshots** (the Safety Manager's backups). Right-click a branch for its actions; use the visibility controls to hide/show branches and declutter a busy graph. Drag its edge to resize.
+- **The commit graph** (centre) — the heart of the app: your history drawn as a swimlane graph on a fast canvas. The row pinned at the very top is **Uncommitted changes** (your working directory); every commit below it is real history. See [Reading the commit graph](/guide/commit-graph).
+- **The detail panel** — selecting a commit shows its full detail (author/committer, signature, diffstat, file tree, and a syntax-highlighted diff). Selecting the top **Uncommitted changes** row instead shows the **working-directory view**, where you stage and commit. See [Committing & staging](/guide/committing).
+- **Tama** — the cat in the corner is GitCat's Safety-Manager mascot. She reacts to what's happening (working, celebrating a success, warning before something risky) and is the friendly face of the snapshot-before-everything system. You can restyle or hide her — see [Tama](/guide/tama).
+
+## Four ways to reach any action
+
+The same operations are reachable more than one way, so you can use whichever fits your hands at the moment:
+
+1. **Point and click** — buttons in the top bar, right-click menus on commits and branches, and drag-and-drop (shift-drag a commit onto `HEAD` to cherry-pick or merge).
+2. **The command palette** — press `⌘K` (`Ctrl+K`) for a fuzzy search over commits, branches, and every tool. This is usually the fastest way to reach something you don't have a shortcut memorized for. See [Command palette & keyboard](/guide/keyboard).
+3. **The menu bar** — the native **File / Repository / Edit / View / Tools / Window / Help** menus hold every action, grouped and labelled, with their keyboard shortcuts shown next to them. Most of the app's tools live under **Tools**.
+4. **The keyboard** — vim-style navigation (`j`/`k`, `gg`/`G`, `Ctrl-D`/`Ctrl-U`, `/` to search) moves around the graph without the mouse, and the common operations have their own shortcuts.
+
+::: tip First run
+The very first time you open GitCat, a short setup wizard helps you pick a repository and check its git identity, then drops you straight into the graph. It only appears once. The next page, [Opening a repository](/guide/opening-a-repository), covers opening and switching repos any time after that.
+:::

--- a/docs/guide/keyboard.md
+++ b/docs/guide/keyboard.md
@@ -1,0 +1,33 @@
+---
+description: GitCat's command palette and keyboard shortcuts — the ⌘K palette, vim-style graph navigation, and the shortcuts for everyday operations.
+---
+
+# Command palette & keyboard
+
+GitCat is built to be driven from the keyboard. The `⌘K` palette reaches anything; vim-style keys move around the graph.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers.
+:::
+
+## What this page will cover
+
+- **The command palette** (`⌘K`) — fuzzy search across commits, refs (including branches not shown in the sidebar), and every tool, plus an in-app **Help** page.
+- **Vim-style navigation** — `j`/`k`, `gg`/`G`, `Ctrl-D`/`Ctrl-U`, `/` to search.
+
+## Shortcut reference (so far)
+
+| Shortcut | Action |
+| --- | --- |
+| `⌘K` | Command palette |
+| `⌘O` | Open / switch repository |
+| `⌘,` | Settings |
+| `⌘⇧H` | Recentre the graph on `HEAD` |
+| `⌘Z` | Undo the last mutation |
+| `⌘⇧N` | New branch |
+| `⌘N` | New window |
+| `⌘F` | Search Code |
+| `⌘⇧F` | Search Commit Content (pickaxe) |
+| `` ⌘` `` | Toggle the built-in terminal |
+
+(On Windows/Linux, use `Ctrl` in place of `⌘`.)

--- a/docs/guide/opening-a-repository.md
+++ b/docs/guide/opening-a-repository.md
@@ -1,0 +1,57 @@
+---
+description: How to open, switch, and close repositories in GitCat — the repositories dashboard, the first-run setup wizard, git identity, and working on several repos at once.
+---
+
+# Opening a repository
+
+GitCat always works on **one repository at a time** in a given window. This page covers getting a repo open, switching between them, and pointing GitCat somewhere new.
+
+## The first time
+
+On first launch, a short **setup wizard** appears. It does three things:
+
+1. **Pick a repository** — click to browse for a folder, or drag a folder straight onto the window.
+2. **Check your git identity** — the name and email your commits will be signed with. If the repository (or your global config) already has one, it's shown for confirmation; if not, you can set it here.
+3. **Jump into the graph.**
+
+The wizard is shown **once**, not on every launch. You can skip it with `Esc` and reach everything it does from the normal UI afterwards.
+
+## Opening or switching repositories
+
+Any time after the first run, open the **Repositories** dashboard:
+
+- Press `⌘O` (`Ctrl+O`), or
+- Click the repository name in the top bar, or
+- Choose **File ▸ Open Repository…**, or the **Open a repository…** button on the empty-state screen.
+
+The dashboard lists the repositories you've opened before (searchable), each with its current branch and status at a glance, so switching back to something you were working on is one click. To bring in a new one, use **+ Add repository…**, which opens a native folder picker.
+
+Selecting a repository loads it into the current window and takes you to its graph.
+
+## Git identity
+
+Your **git identity** (the name and email on your commits) can be set per repository or globally. To view or change it for the repo that's open:
+
+- **Settings ▸ Git Identity** (`⌘,` opens Settings), or the identity step surfaced by the setup wizard.
+
+GitCat writes a per-repository identity only to that repo's `.git/config` — your global identity is never touched unless you explicitly edit the **Global** scope in [Settings ▸ Git Config](/guide/settings).
+
+## Closing and the empty state
+
+**File ▸ Close Repository** returns GitCat to its empty state — a clean way to step away from the current repo without quitting. From there you can open a different one exactly as above. (You never have to quit and relaunch just to point GitCat somewhere else.)
+
+## Submodules
+
+If the open repository has submodules, a slim strip appears under the top bar. From there you can init/update them (including `--recursive`), add or remove one, and — most usefully — **Open** a submodule to manage it exactly like a top-level repository, then come back. Submodule status (up to date, needs update, has local edits) is shown so you know what needs attention.
+
+## Working on several repos at once
+
+To keep two repositories open side by side, use **Window ▸ New Window** (`⌘N`). Each window is fully independent — pick a different repository in each, and an operation in one never affects the other.
+
+## Staying in sync with the outside world
+
+Once a repo is open, GitCat keeps up with changes made **outside** the app — a commit from a terminal, a background fetch, another tool — and refreshes the graph and working-directory view on its own. If you ever want to force a resync, the **Refresh** button in the top bar (or **Repository ▸ Refresh**) does a full reload.
+
+---
+
+Next: [Reading the commit graph](/guide/commit-graph).

--- a/docs/guide/plugins.md
+++ b/docs/guide/plugins.md
@@ -1,0 +1,23 @@
+---
+description: Using plugins in GitCat — install, enable, disable, and remove them from the Plugins manager. For writing your own, see the plugin authoring guide.
+---
+
+# Plugins
+
+Plugins extend GitCat with extra `⌘K` commands, lifecycle hooks, panels, and Tama skins. This page is about **using** them; to **write** one, see the dedicated [plugin authoring guide](/plugins).
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers.
+:::
+
+## What this page will cover
+
+- **The Plugins manager** — open it from **Tools ▸ Plugins…** or `⌘K`. It's a two-pane view: the installed plugins on the left, the selected one's details on the right (what it contributes, plus its enable and remove controls).
+- **Install from a file** — GitCat plugins are local files (there's no online store); install one by picking its `plugin.json`.
+- **Enable / disable** a plugin with its toggle, or **remove** it (which unregisters it — the `plugin.json` on disk is left untouched).
+- **What a plugin can contribute** — `⌘K` commands, lifecycle hooks, declarative panels, a Tama skin, and Luau-scripted handlers.
+- **The trust boundary** — GitCat never connects to anything itself; a plugin only runs the external commands (or sandboxed Luau) it declares. Install only plugins you trust.
+
+## Writing your own
+
+The full manifest reference, the placeholder grammar, hooks, panels, Tama skins, and Luau scripting all live in the [plugin authoring guide](/plugins).

--- a/docs/guide/rebasing.md
+++ b/docs/guide/rebasing.md
@@ -1,0 +1,18 @@
+---
+description: Rebasing in GitCat — linear rebase onto another branch, and the drag-to-reorder interactive rebase planner (pick / edit / squash / fixup / drop).
+---
+
+# Rebasing
+
+Replaying commits onto a new base — linear or interactive — with the safety net on the whole time.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers; the [Features](/features) list has the short version in the meantime.
+:::
+
+## What this page will cover
+
+- **Linear rebase** onto any branch, including working through multi-commit conflict sequences and skipping a commit mid-sequence.
+- **Interactive rebase** — a **drag-to-reorder planner** (pick / edit / squash / fixup / drop) that you arrange *before* it ever touches your history.
+- How conflicts during a rebase hand off to the [3-way resolver](/guide/combining).
+- Why a rebase is safe to try here: a snapshot is pinned first, so `⌘Z` [undoes the whole rebase](/guide/undo-safety) in one step.

--- a/docs/guide/remotes.md
+++ b/docs/guide/remotes.md
@@ -1,0 +1,20 @@
+---
+description: Syncing with remotes in GitCat — fetch, pull (merge or rebase), push, managing remotes, and the two safe kinds of force push.
+---
+
+# Syncing with remotes
+
+Fetching, pulling, and pushing — and doing the risky remote operations safely.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers; the [Features](/features) list has the short version in the meantime.
+:::
+
+## What this page will cover
+
+- **Fetch / Pull / Push** from the top bar or the native **Repository** menu.
+- **Pull asks merge or rebase explicitly** — it never silently picks a strategy behind your back, and follows your configured upstream automatically.
+- **Pushing a non-current branch**, or pushing to a differently-named remote branch, right from the sidebar.
+- **Manage Remotes** — add, edit, rename, and remove remotes from a dialog instead of hand-editing `.git/config` (**Tools ▸ Manage Remotes**).
+- **Force push, made safe** — the explicit choice between **force-with-lease** (refuses if the remote moved since your last fetch) and a raw **override**, both behind a typed danger-confirm.
+- **Auto-fetch** — an optional background `git fetch --all --prune` on a timer, so ahead/behind counts stay current (opt-in, in [Settings](/guide/settings)).

--- a/docs/guide/rewriting-history.md
+++ b/docs/guide/rewriting-history.md
@@ -1,0 +1,23 @@
+---
+description: Rewriting history in GitCat with the git-filter-repo wizard — scope, preview, typed confirmation, and a full backup/restore safety net.
+---
+
+# Rewriting history
+
+The one genuinely irreversible-by-normal-Undo operation in GitCat gets its own careful, multi-step wizard.
+
+::: warning The heavy operation
+Rewriting history changes every affected commit's hash and expires the reflog. GitCat wraps it in a dedicated wizard with a full backup and restore step *on top of* the usual snapshot — but it's still the biggest thing you can do to a repository, so it's worth understanding before you run it.
+:::
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers.
+:::
+
+## What this page will cover
+
+- Opening the wizard (**Tools ▸ Rewrite History (filter-repo)…**).
+- **Scope** — choosing what to rewrite (paths, and so on).
+- **Preview** — seeing what the rewrite will do before it runs.
+- **Typed confirmation** — the deliberate "yes, I mean it" gate.
+- **Backup & restore** — the dedicated safety net, separate from the ordinary snapshot, and how to restore from it.

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -1,0 +1,38 @@
+---
+description: A reference for GitCat's Settings — appearance, graph, updates, auto-fetch, snapshots, Tama, git identity, and git config.
+---
+
+# Settings
+
+Open Settings with `⌘,` or **Tools ▸ Settings…**. It's organized into tabs; this page is a reference for what each one holds.
+
+::: info This page is being expanded
+The full reference is on its way. Here's the outline of what it covers.
+:::
+
+## What this page will cover
+
+### General
+
+- **Appearance** — theme (match system / light / dark).
+- **Graph** — show all tags on a commit; whether tags or branches take priority in a crowded gutter.
+- **Cherry-pick** — record origin (`-x`) by default.
+- **Updates** — check for updates now, automatic check on launch, and the nightly-build channel.
+- **Auto-fetch** — periodically fetch from all remotes, and how often.
+- **Snapshots** — the [Safety Manager](/guide/undo-safety) retention policy (keep everything / newest N / last N days / hybrid).
+
+### Tama
+
+- Show Tama, sound effects + volume, skin, motion preset, and per-moment expression remapping. See [Tama](/guide/tama).
+
+### Git Identity
+
+- The name and email on your commits, scoped to the open repository.
+
+### Git Config
+
+- Curated common keys (line endings, pull strategy, editor, default branch name) at **local** or **global** scope, plus an **Advanced** editor for any key.
+
+::: tip Plugins moved out
+Plugin management is no longer a Settings tab — it has its own view at **Tools ▸ Plugins…**. See [Plugins](/guide/plugins).
+:::

--- a/docs/guide/tama.md
+++ b/docs/guide/tama.md
@@ -1,0 +1,22 @@
+---
+description: Tama, GitCat's Safety-Manager mascot — what her reactions mean, and how to customize her expressions, motion, voice, skin, or hide her entirely.
+---
+
+# Tama
+
+Tama is the cat in the corner — GitCat's Safety-Manager mascot and the friendly face of the snapshot-before-everything system.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers.
+:::
+
+## What this page will cover
+
+- **What her reactions mean** — she pins a snapshot before every mutation and reacts to what's happening: working, celebrating a success, warning before something risky.
+- **Customizing her** (in **Settings ▸ Tama**):
+  - **Show Tama** — hide her portraits everywhere for a plainer look (status messages still show).
+  - **Sound effects** — a few short chimes for her more significant moments, with a volume slider and a Test button.
+  - **Skin** — swap her look and voice for a bundled character or one shipped by a [plugin](/guide/plugins).
+  - **Motion** — how lively her idle animation and reactions feel (Default / Calm / Lively).
+  - **Expressions** — remap which face she makes for each moment.
+- How plugins can trigger Tama reactions and ship a skin (see [Writing a plugin](/plugins)).

--- a/docs/guide/terminal-tools.md
+++ b/docs/guide/terminal-tools.md
@@ -1,0 +1,17 @@
+---
+description: GitCat's built-in terminal and pluggable external diff/merge tools — drop into a real shell at the repo root, or hand a diff or conflict to your own tool.
+---
+
+# Terminal & external tools
+
+For the moments you want a raw shell, or your own diff/merge tool instead of the built-in view.
+
+::: info This page is being expanded
+The full walkthrough is on its way. Here's the outline of what it covers.
+:::
+
+## What this page will cover
+
+- **The built-in terminal** — a real PTY-backed shell embedded in GitCat, rooted at the open repository. Toggle it with `` ⌘` `` or **Tools ▸ Open Terminal**; its scrollback stays alive across hide/show.
+- **External diff/merge tools** — configure your own tool (VS Code, Beyond Compare, or anything else) and hand a file's diff or a conflict off to it instead of GitCat's built-in view. Set up under **Tools ▸ External Tools**.
+- Where the per-file "Open in external diff" / "Resolve with external tool" actions appear (the working-directory and detail file rows, and the conflict resolver).

--- a/docs/guide/undo-safety.md
+++ b/docs/guide/undo-safety.md
@@ -1,0 +1,56 @@
+---
+description: GitCat's Safety Manager — how the snapshot-before-every-mutation system works, how to undo (and undo the undo), snapshot retention, and the recovery tools that back it up.
+---
+
+# Undo & the Safety Manager
+
+This is the page that makes the rest of GitCat safe to explore. The **Safety Manager** is the system that lets you try things — a rebase, a reset, a cherry-pick you're not sure about — knowing you can always get back.
+
+## How it works
+
+Before **any** operation that changes your history or working tree, GitCat pins a **snapshot** of the repository. You don't do anything to make this happen; it's automatic and it covers every mutation.
+
+That snapshot is what **Undo** restores from:
+
+- **Undo** — `⌘Z` (`Ctrl+Z`). Rolls the repository back to just before the last mutation.
+- **Undo is itself undoable.** Restoring a snapshot is just another snapshotted mutation, so if you undo one step too far, undo again (or redo) to come back. There's no single click in the app that drops you somewhere you can't get out of.
+
+Tama, the cat in the corner, is the face of this system — she pins the snapshot before the mutation and reacts to what's happening, so the safety net always feels present rather than hidden.
+
+## Snapshots in the sidebar
+
+Every snapshot is listed in the **Snapshots** section of the sidebar (and a ribbon on the graph). You can browse them and restore to any one, not just the most recent — handy when you want to jump back several operations at once. Each restore is, again, snapshot-first and undoable.
+
+Under the hood these are backup refs stored inside your repo, so they survive quitting and reopening GitCat.
+
+## Keeping snapshots tidy
+
+Because every mutation adds one, snapshots accumulate. **Settings ▸ General ▸ Snapshots** controls automatic cleanup, run each time a repo opens:
+
+- **Keep everything** (default) — no cleanup; nothing is ever pruned automatically.
+- **Keep the newest N**,
+- **Keep the last N days**, or
+- **Hybrid** — keep a snapshot if it's among the newest N *or* from the last N days.
+
+Whatever you pick, the **single most recent snapshot is always kept** — "undo my last action" never gets cleaned away.
+
+## The recovery tools behind it
+
+The Safety Manager is more than one Undo key. A family of tools (all under **Tools**, and covered in [History & recovery tools](/guide/history-tools)) exist for getting out of specific situations:
+
+- **Reflog rescue** — browse every historical position `HEAD` has been in and restore to any of them. The restore is a normal snapshot-first, undoable mutation.
+- **Dangling-object recovery** — runs `git fsck` to find a commit that no branch, tag, or reflog points to anymore, and brings it back as a new branch without touching your current branch or `HEAD`.
+
+## When an action is genuinely risky
+
+A few operations can lose work in a way a snapshot can't fully paper over, so GitCat gates them explicitly rather than letting you stumble into them:
+
+- **Switching branches with uncommitted changes** — instead of silently stashing or refusing, GitCat offers three explicit paths in increasing order of risk: **stash → switch → reapply**; **stash → switch → leave stashed** (recover it later from Manage Stash); or **force-switch and discard**, which is genuinely irreversible and sits behind a typed danger-confirm.
+- **Force push** — a real choice between **force-with-lease** (refuses if the remote moved since your last fetch) and a raw **override**, both behind the same typed danger-confirm. See [Syncing with remotes](/guide/remotes).
+- **Rewriting history with `filter-repo`** — the one genuinely irreversible-by-normal-Undo operation gets its own dedicated wizard with a full backup and restore step on top of the usual snapshot. See [Rewriting history](/guide/rewriting-history).
+
+The pattern is consistent: the everyday stuff is freely reversible with `⌘Z`, and the rare irreversible actions announce themselves and make you type to confirm.
+
+---
+
+Next: [History & recovery tools](/guide/history-tools).


### PR DESCRIPTION
Add a task-oriented user manual under docs/guide/, complementing the existing Features page (which sells) with how-to guidance (which teaches). Wires a new "Guide" nav entry + a grouped sidebar into the VitePress config, scoped to /guide/ so the other pages stay sidebar-less.

Fully written (core):
- Overview & layout (the Guide landing) — the one-idea (everything reversible), a map of the window, and the four ways to reach any action.
- Opening a repository — setup wizard, the dashboard, identity, close, submodules, multi-window, live refresh.
- Reading the commit graph — HEAD marker, dimmed-merged, ref labels, selecting, acting (right-click / shift-drag), keyboard nav, busy-graph controls.
- Committing & staging — the working-dir view, whole-file + hunk/line staging, writing the commit, stash, per-file blame/history.
- Undo & the Safety Manager — snapshot-before-every-mutation, undo(-of-undo), the Snapshots ribbon, retention policy, and the recovery/danger-gate tools.

Scaffolded (intro + outline, being expanded): branches, remotes, combining (cherry-pick/merge/revert), rebasing, history-tools, rewriting-history, keyboard, terminal-tools, tama, plugins (using the manager), settings.

On the docs/user-manual branch only — NOT main — so the GitHub Pages site is not redeployed (docs.yml triggers on push to main touching docs/**). `pnpm docs:build` clean (no dead links); preview locally with `pnpm docs:dev` → /guide/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fa81f60dc86c13a9efad305e40f3c8e3b7b2cb9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->