### PR TITLE
Fix: branch-visibility changes never reached the graph

### DIFF
--- a/src/islands/sidebar/sidebar.svelte.test.ts
+++ b/src/islands/sidebar/sidebar.svelte.test.ts
@@ -119,6 +119,10 @@ function resetAll() {
   // care about this" reasoning as submoduleStatus above — only the
   // "branch visibility" describe block overrides this per-test.
   vi.mocked(commands.getVisibleBranches).mockResolvedValue(ok({ local: null, remote: null, auto: false }));
+  // Default: persisting succeeds. persistVisibleBranches checks this Result and
+  // skips the graph reload when it failed, so without a default every test that
+  // changes visibility would take the failure path instead.
+  vi.mocked(commands.setVisibleBranches).mockResolvedValue(ok(null));
 }
 
 beforeEach(() => {
@@ -246,7 +250,8 @@ describe("branch visibility", () => {
     await sidebarCtrl.toggleBranchVisible("/repo", "local", "dev");
     expect(sidebarCtrl.visibleLocal).toEqual(["main"]);
     expect(commands.setVisibleBranches).toHaveBeenCalledWith("/repo", false, ["main"], null);
-    expect(bridge.reloadGraph).toHaveBeenCalledWith(true);
+    // forceFull — see persistVisibleBranches' own doc comment.
+    expect(bridge.reloadGraph).toHaveBeenCalledWith(true, true);
   });
 
   it("toggleBranchVisible: a manual toggle turns auto mode off (grabbing the wheel exits autopilot)", async () => {
@@ -286,7 +291,7 @@ describe("branch visibility", () => {
     expect(sidebarCtrl.visibleLocal).toBeNull();
     expect(sidebarCtrl.visibleRemote).toBeNull();
     expect(commands.setVisibleBranches).toHaveBeenCalledWith("/repo", false, null, null);
-    expect(bridge.reloadGraph).toHaveBeenCalledWith(true);
+    expect(bridge.reloadGraph).toHaveBeenCalledWith(true, true);
   });
 
   it("hideAllBranches sets both sets to [] (not null) AND turns off auto mode, and persists", async () => {
@@ -301,7 +306,65 @@ describe("branch visibility", () => {
     expect(sidebarCtrl.visibleLocal).toEqual([]);
     expect(sidebarCtrl.visibleRemote).toEqual([]);
     expect(commands.setVisibleBranches).toHaveBeenCalledWith("/repo", false, [], []);
-    expect(bridge.reloadGraph).toHaveBeenCalledWith(true);
+    expect(bridge.reloadGraph).toHaveBeenCalledWith(true, true);
+  });
+
+  // REGRESSION: every visibility change must force a FULL graph reload.
+  //
+  // A visibility change decides which commits the graph walks from, so it adds
+  // or removes rows — something reloadGraph's fast path cannot express, since
+  // all it does is remap ref chips over rows that are already loaded. Omitting
+  // forceFull once left the filter persisted and applied while the graph kept
+  // every commit, because a visibility toggle moves no ref and does not move
+  // HEAD, so that path classified it as a pure working-tree change and returned
+  // successfully having done nothing.
+  //
+  // Asserted per entry point rather than once, since each reaches
+  // persistVisibleBranches by its own route.
+  it.each([
+    ["toggleBranchVisible", () => sidebarCtrl.toggleBranchVisible("/repo", "local", "dev")],
+    ["showAllBranches", () => sidebarCtrl.showAllBranches("/repo")],
+    ["hideAllBranches", () => sidebarCtrl.hideAllBranches("/repo")],
+    ["toggleAutoMode", () => sidebarCtrl.toggleAutoMode("/repo")],
+  ])("%s forces a full graph reload, never the fast path", async (_name, act) => {
+    mockInTauri = true;
+    vi.mocked(commands.branchMergeStatus).mockResolvedValue(ok({ defaultBranch: "main", merged: [] }));
+    sidebarCtrl.locals = [
+      { name: "main", sha: "a", ahead: null, behind: null, upstream: null, lastCommitTime: NOW },
+      { name: "dev", sha: "b", ahead: null, behind: null, upstream: null, lastCommitTime: NOW },
+    ];
+    await act();
+    expect(bridge.reloadGraph).toHaveBeenCalledWith(true, true);
+    // Never the fast-path-eligible single-argument form.
+    expect(bridge.reloadGraph).not.toHaveBeenCalledWith(true);
+  });
+
+  // The flip side of forcing a full reload: a full reload is expensive, and it
+  // ends by re-reading the persisted filter. If persisting failed there is
+  // nothing new to walk to, so paying for the walk would only put the old
+  // picture back on screen — with the checkbox silently snapping back and no
+  // word to the user about why.
+  it.each([
+    ["a rejected Result", () => vi.mocked(commands.setVisibleBranches).mockResolvedValue({ status: "error", error: "read-only registry" })],
+    ["a thrown error", () => vi.mocked(commands.setVisibleBranches).mockRejectedValue(new Error("ipc down"))],
+  ])("a visibility change that fails to persist (%s) warns instead of reloading the graph", async (_name, failPersist) => {
+    mockInTauri = true;
+    sidebarCtrl.locals = [
+      { name: "main", sha: "a", ahead: null, behind: null, upstream: null, lastCommitTime: NOW },
+      { name: "dev", sha: "b", ahead: null, behind: null, upstream: null, lastCommitTime: NOW },
+    ];
+    failPersist();
+    // What the backend still has: the unfiltered state the toggle tried to leave.
+    vi.mocked(commands.getVisibleBranches).mockResolvedValue(ok({ local: null, remote: null, auto: false }));
+
+    await sidebarCtrl.toggleBranchVisible("/repo", "local", "dev");
+
+    expect(bridge.reloadGraph).not.toHaveBeenCalled();
+    expect(bridge.tama.warn).toHaveBeenCalledWith(expect.stringContaining("Couldn't save"));
+    // Re-read from the backend, so the sidebar shows the filter that's really
+    // stored rather than the one it failed to store.
+    expect(commands.getVisibleBranches).toHaveBeenCalledWith("/repo");
+    expect(sidebarCtrl.visibleLocal).toBeNull();
   });
 
   it("hideAllBranches makes isBranchVisible false for every branch", async () => {

--- a/src/islands/sidebar/sidebar.svelte.ts
+++ b/src/islands/sidebar/sidebar.svelte.ts
@@ -676,12 +676,29 @@ class SidebarState {
 
   private async persistVisibleBranches(repo: string): Promise<void> {
     if (!IN_TAURI || !repo) return; // design-mode: local state only, nothing to persist/reload
+    let persisted = false;
     try {
-      await commands.setVisibleBranches(repo, this.autoMode, this.visibleLocal, this.visibleRemote);
+      const res = await commands.setVisibleBranches(repo, this.autoMode, this.visibleLocal, this.visibleRemote);
+      if (res.status === "ok") persisted = true;
+      else console.error("set_visible_branches", res.error);
     } catch (e) {
       console.error("set_visible_branches", e);
     }
-    await bridge.reloadGraph(true);
+    if (!persisted) {
+      // Nothing was stored, so the graph already matches the filter the backend
+      // would walk with — reloading would spend a whole re-walk arriving back at
+      // the same picture. Say so instead, and put the checkboxes back on the
+      // persisted truth so the sidebar can't show a filter that isn't there.
+      bridge.tama.warn("Couldn't save which branches to show.");
+      await this.refreshVisibleBranches(repo);
+      return;
+    }
+    // forceFull is load-bearing: which branches are visible decides which
+    // commits the walk seeds from, so this ADDS OR REMOVES ROWS. reloadGraph's
+    // fast path only remaps ref chips over rows that are already loaded, so it
+    // has no way to express that; without forceFull the filter is persisted and
+    // the graph silently keeps every commit.
+    await bridge.reloadGraph(true, true);
   }
 
   private async refreshSubmodules(repo: string) {
@@ -1826,6 +1843,12 @@ class SidebarState {
     try {
       const res = await commands.renameBranch(bridge.CUR_REPO as unknown as string, from, to);
       if (res && res.ok) {
+        // Keep a renamed branch in the visible set under its new name, and
+        // persist that directly for the same reason confirmNewBranch does (see
+        // its own comment): the reloadGraph(true) below is the only reload. It
+        // stays on the fast path deliberately — a rename moves no commit, so no
+        // row appears or disappears and there is nothing for a full re-walk to
+        // find, unlike a visibility change.
         if (this.visibleLocal !== null && this.visibleLocal.includes(from)) {
           this.visibleLocal = this.visibleLocal.map((b) => (b === from ? to : b));
           try {

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -2880,9 +2880,10 @@ async function tryFastRefresh(){
   // Advance the baseline before any async work / re-entrant refresh sees it.
   loadedSeedTips=curTipSet; loadedHeadOid=cur.headOid; lastRefSig=cur.refSig;
   // Pill + refs tree + auto-visibility (keeps its own sameLocal&&sameRemote echo
-  // guard — a checkout that auto-hides a branch queues one more pass that Gate B
-  // then turns into a full reload). Safety.refresh keeps the undo count current
-  // for the DAG-preserving mutations that still take a snapshot (e.g. checkout).
+  // guard — a checkout that auto-hides a branch persists that, which reloads the
+  // graph in full on its own, so this fast pass must not be the last word on
+  // which rows are shown). Safety.refresh keeps the undo count current for the
+  // DAG-preserving mutations that still take a snapshot (e.g. checkout).
   await sidebarCtrl.refresh(CUR_REPO); await Safety.refresh();
   if(headMoved) recomputeAncestorsAsync();
   return true;


### PR DESCRIPTION
## Symptom

Toggling a branch checkbox — or clicking Auto / Show all branches / Hide all branches — visibly changed the sidebar's own state and persisted correctly, and did nothing at all to the commit graph. Every commit stayed, every hidden branch kept its label, until some unrelated event forced a full reload (the manual Refresh button, or reopening the repo).

Measured on a 93k-commit repo with "Hide all branches" persisted as `{local: [], remote: []}`:

| layer | result |
| --- | --- |
| `walk_repo`, no filter | 93,545 commits / 19 branch chips / 392 remote chips |
| `walk_repo`, filtered | 58,630 commits / 0 chips |
| actually on screen | 93,544 commits, all chips present |

The backend was correct at every layer — the registry lookup resolved the row, `walk_repo` honored the filter, `filter_hidden_chips` dropped the chips. The change was being discarded in the frontend's reload path.

## Root cause

`persistVisibleBranches` called `bridge.reloadGraph(true)`. That signature is `reloadGraph(preserveRow, forceFull = false)`, so this only asked to preserve the selected row and left the fast path enabled. But a visibility change decides which commits the walk seeds from, so it **adds or removes rows** — and the fast path only ever remaps ref chips over rows that are already loaded. It cannot express the change; and because a visibility toggle moves no ref and does not move HEAD, that path classified it as a pure working-tree change and returned successfully having done nothing.

## Fix

- `persistVisibleBranches` now forces a full reload (`reloadGraph(true, true)`), rather than teaching the fast path filter-awareness — no amount of better change detection helps when the path has no mechanism for adding or removing rows in the first place.
- The flip side: a full reload is expensive and ends by re-reading the persisted filter, so the `set_visible_branches` **Result is now checked** before paying for one. Previously only the thrown half was handled; a rejected Result went straight on to force a re-walk that could only put the old picture back, with the user's checkbox silently snapping back and nothing said about why. Both failure halves now warn through Tama and re-read the stored filter.
- Comment repairs that this change made necessary: `tryFastRefresh`'s note on the auto-visibility pass described Gate B promoting it to a full reload, which stops being how it works with this fix; and the branch-rename path now states why it deliberately stays on the fast path (a rename moves no commit, so no row can appear or disappear).

## Verification

- Regression tests for all four entry points (toggle / show all / hide all / auto), asserting both the `(true, true)` call and the **absence** of the fast-path-eligible one-argument form. All four fail against the old call.
- 2 tests for the failed-persist path (rejected Result, thrown error): no reload, a warning, and a re-read of the stored filter.
- 215 sidebar tests / full suite green; `svelte-check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
