### PR TITLE
Declare the package manager once, in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,6 @@ jobs:
       # `pnpm store path` to locate what to cache.
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node
         uses: actions/setup-node@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node
         uses: actions/setup-node@v6

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,8 +137,6 @@ jobs:
           ref: ${{ needs.gate.outputs.sha }} # the EXACT commit the gate captured + versioned, not the moving dev tip
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - name: Install Node
         uses: actions/setup-node@v6
         with:
@@ -205,8 +203,6 @@ jobs:
           ref: ${{ needs.gate.outputs.sha }} # the EXACT commit the gate captured + versioned, not the moving dev tip
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - name: Install Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,6 @@ jobs:
       # to `pnpm store path` to locate what to cache (same as ci.yml).
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -107,7 +107,15 @@ Download the installer for your platform from the [Releases page](https://github
 
 ## Development
 
-Requires [Rust](https://www.rust-lang.org/tools/install), [Node](https://nodejs.org) 22+, and [pnpm](https://pnpm.io). On Linux, Tauri also needs WebKitGTK/GTK3 dev headers at build time — see `.github/workflows/*.yml` for the apt packages, or on NixOS run `nix develop` to drop into a shell with everything (Rust, Node, pnpm, WebKitGTK, and friends) already wired up via `flake.nix`.
+Requires [Rust](https://www.rust-lang.org/tools/install), [Node](https://nodejs.org) 22+, and [pnpm](https://pnpm.io) 10. On Linux, Tauri also needs WebKitGTK/GTK3 dev headers at build time — see `.github/workflows/*.yml` for the apt packages, or on NixOS run `nix develop` to drop into a shell with everything (Rust, Node, pnpm, WebKitGTK, and friends) already wired up via `flake.nix`.
+
+The exact pnpm version lives in `package.json`'s `packageManager` field, which is what keeps `pnpm-lock.yaml` from being rewritten by whichever pnpm you happen to have. Any pnpm 10 honours it on its own. Older pnpm does not — it will run as itself and fail here — so if you have pnpm 9 or none at all, let corepack (bundled with Node) handle it:
+
+```bash
+corepack enable pnpm
+```
+
+Then, from the repo root:
 
 ```bash
 pnpm install

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "license": "GPL-3.0-or-later",
   "type": "module",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "vite",
     "build": "svelte-check --tsconfig ./tsconfig.json && vite build",


### PR DESCRIPTION
## Why

`pnpm-lock.yaml` is committed, but nothing in the repo said which pnpm produced it. The version lived only in CI, repeated as `version: 10` at five `pnpm/action-setup` call sites — so a contributor's local pnpm was whatever they happened to have installed, and running `pnpm install` under a different major rewrites the lockfile as a side effect of an unrelated command.

## What

`"packageManager": "pnpm@10.34.5"` in package.json. Measured, since the field is only as good as what reads it:

| scenario | result |
| --- | --- |
| pnpm 10 in this repo, field present | reports 10.34.5 (self-switches) |
| pnpm 10, field removed | reports its own version |
| pnpm 9 in this repo | stays on 9, then dies with "packages field missing or empty" |

So pnpm 10 honours the pin unaided, and pnpm 9 neither honours it nor limps along. README's Development section now says exactly that and points anyone on 9 (or with no pnpm) at `corepack enable pnpm`.

The five `version: 10` inputs **have to go in the same commit**, not separately: `pnpm/action-setup` refuses to run when a version is specified both in its input and in `packageManager` — it fails with "Multiple versions of pnpm specified". Adding the field alone would have broken ci.yml, docs.yml, nightly.yml (two jobs), and release.yml. Dropping the inputs is also the point: one declaration, read by both CI and every local checkout, instead of two that can drift.

`10.34.5` specifically: what `pnpm@10` currently resolves to, and what the committed lockfile matches. Corepack requires an exact semver here — `pnpm@10.x` is rejected outright.

## Two things worth your eyes

**1. `nix build .#default` — could not verify.** `nix/package.nix` runs `pnpm install` through nixpkgs' `pnpmConfigHook` inside the no-network build sandbox, using nixpkgs' own pnpm. Since pnpm 10 self-switches to the pinned version — and downloads it when absent — that hook could fail if nixpkgs' pnpm isn't already 10.34.5 and nixpkgs doesn't disable the behaviour. I don't have a Nix machine to test on. If it bites, `manage-package-manager-versions=false` in an `.npmrc` is the escape hatch (at the cost of the local half of this change).

**2. nightly.yml's comment says "main is the default branch" — the repo's actual default is `dev`.** Checked before touching that file: `dev` is 24 commits ahead of `main` with none the other way, so the scheduled run reading its workflow (and tree) from `dev` is consistent today, and this PR's edits to nightly.yml are safe either way. Flagging rather than editing your comment — worth a look at whether `main` or the comment is the thing to update.

**Heads-up:** #14 adds one more `pnpm/action-setup` step with `version: 10` — whichever of the two PRs lands second needs that one line brought in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
