### PR TITLE
ci: bump actions/cache + upload-artifact to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
       # re-downloads.
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -259,7 +259,7 @@ jobs:
       # traces (trace: "on-first-retry") only exist when something retried.
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
       # path: it does not touch Releases.
       - name: Upload bundles (manual build only)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: gitcat-${{ matrix.target }}
           path: |


### PR DESCRIPTION
Fixes the GitHub Actions deprecation warning on the E2E (Playwright) job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`.

GitHub is [sunsetting Node 20 on runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). `actions/cache@v4` runs on Node 20; `v5` is the Node 24 release with the same inputs.

## Changes

- `actions/cache@v4` → `@v5` — the E2E job's Playwright browser cache (`ci.yml`), the one in the warning.
- `actions/upload-artifact@v4` → `@v5` in both places it's used (`ci.yml`'s failure-only report upload and `release.yml`'s manual-build bundle upload) — same Node 20 deprecation, so bumping now avoids the identical warning surfacing there next.

Every other action already targets Node 24 (`checkout@v7`, `setup-node@v6`, `github-script@v8`, the Pages actions). Version bumps only, inputs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)