### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Limit the GITHUB_TOKEN to the least privilege this suite actually needs.
+# Without an explicit block the token defaults to broad, mostly-write scopes
+# (CodeQL flags this as actions/missing-workflow-permissions). Every job here
+# only builds and tests: `actions/checkout` needs `contents: read`, and nothing
+# writes back to the repo. The e2e job's `upload-artifact` uses the Actions
+# runtime token, not GITHUB_TOKEN scopes, and `$GITHUB_STEP_SUMMARY` is a plain
+# env-file write, so neither needs anything beyond read. Declared at workflow
+# level so it applies to all four jobs (rust, rust-windows, frontend, e2e).
+permissions:
+  contents: read
+
 jobs:
   # Builds/tests the Rust core (src-tauri, crate `gitcat_lib`).
   # Independent of the `frontend` job below so the two run in parallel.


### PR DESCRIPTION
## What

Adds a workflow-level `permissions: contents: read` block to `.github/workflows/ci.yml`.

## Why

`ci.yml` was the only workflow in the repo without an explicit `permissions:` block, so its `GITHUB_TOKEN` fell back to the broad default scopes. CodeQL's `actions/missing-workflow-permissions` rule flagged all four of its jobs:

- [Alert #1](https://github.com/zangjiucheng/GitCat/security/code-scanning/1) — `rust`
- [Alert #3](https://github.com/zangjiucheng/GitCat/security/code-scanning/3) — `frontend`
- [Alert #4](https://github.com/zangjiucheng/GitCat/security/code-scanning/4) — `e2e`
- [Alert #5](https://github.com/zangjiucheng/GitCat/security/code-scanning/5) — `rust-windows`

## Why `contents: read` is enough

Every job in this suite only builds and tests:

- `actions/checkout` needs `contents: read`.
- Nothing writes back to the repository (no commits, tags, comments, or releases).
- The e2e job's `upload-artifact` uses the Actions runtime token, not `GITHUB_TOKEN` scopes.
- `$GITHUB_STEP_SUMMARY` is a plain env-file write and needs no token permission.

Declared at workflow level so it applies to all four jobs at once. This matches the explicit `permissions:` blocks already present in `docs.yml`, `nightly.yml`, and `release.yml` (the write-scoped ones there need it; CI does not).

## Verification

`ci.yml` parses cleanly (`permissions: {contents: read}`, all four jobs intact). This is a workflow-metadata-only change; the jobs themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)