### PR TITLE
fix(cli): Windows `gitcat .` blank graph + WSL launcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This needs the `gitcat` command on your `PATH`. Open GitCat and run **Install 'g
 
 - **macOS** — `/usr/local/bin/gitcat` (you may be asked for your password).
 - **Linux** — `~/.local/bin/gitcat` (make sure that folder is on your `PATH`). The `.deb`/`.rpm` packages already put `gitcat` on `PATH` too, so this is mainly for the AppImage.
-- **Windows** — `gitcat.cmd` under `%LOCALAPPDATA%\Microsoft\WindowsApps`, which is on `PATH` by default.
+- **Windows** — `gitcat.cmd` under `%LOCALAPPDATA%\Microsoft\WindowsApps`, which is on `PATH` by default. It also drops a `gitcat` launcher into each installed WSL distro (`~/.local/bin/gitcat`), so `gitcat .` works from a WSL shell too and opens the app on the repo at its `\\wsl.localhost\<distro>\...` path.
 
 Open a new terminal afterwards so it picks up the change.
 

--- a/src-tauri/src/cli_shim.rs
+++ b/src-tauri/src/cli_shim.rs
@@ -27,6 +27,14 @@
 //!     `%LOCALAPPDATA%\Microsoft\WindowsApps` (user-writable and on PATH by
 //!     default). It uses `start "" /D "%CD%"` so the terminal isn't blocked and
 //!     the new process is pinned to the caller's directory for relative paths.
+//!     It ALSO best-effort installs a Linux launcher into every detected WSL
+//!     distro (`~/.local/bin/gitcat`), so `gitcat .` works from a WSL shell too
+//!     — the `.cmd` shim can't run there (WSL interop only executes PE binaries,
+//!     not batch files). That launcher converts the repo path with `wslpath -w`
+//!     and hands the resulting `\\wsl.localhost\<distro>\...` path to the Windows
+//!     app, which already routes a WSL repo through `wsl.exe` (see `wsl.rs`).
+//!     WSL being absent, or a single distro failing, is not an error — the
+//!     Windows `.cmd` is the primary result and is what the reported path names.
 //!
 //! The script-building is kept in pure functions (compiled and unit-tested on
 //! every platform via `cfg(any(target_os = …, test))`), so the fiddly launcher
@@ -63,7 +71,7 @@ pub fn install_cli_shim() -> Result<String, String> {
 /// single quote into the `'\''` idiom (close quote, escaped quote, reopen).
 /// Single quotes disable every shell metacharacter ($, `, \, "...), so an
 /// install path with any of them can't break or hijack the launcher.
-#[cfg(any(unix, test))]
+#[cfg(any(unix, target_os = "windows", test))]
 fn sh_single_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
@@ -134,6 +142,80 @@ rem `start` returns immediately so this terminal isn't blocked; /D pins the new\
 rem process to the current directory so a relative path (gitcat .) resolves here.\r\n\
 start \"\" /D \"%CD%\" \"{exe}\" %*\r\n"
     )
+}
+
+/// The Linux `gitcat` launcher installed *inside* a WSL distro (at
+/// `~/.local/bin/gitcat`), so `gitcat .` works from a WSL shell too. The Windows
+/// `.cmd` shim can't be run from inside WSL — interop only executes PE binaries,
+/// not batch files — so a WSL user needs a native launcher that reaches back out
+/// to the Windows app.
+///
+/// `win_exe` is gitcat.exe's Windows path (`C:\…\gitcat.exe`), baked in and
+/// translated to the distro's own mount point with `wslpath -u` at RUN time (so
+/// it survives a distro with a non-default `/mnt` root). A directory argument is
+/// resolved to an absolute path and converted to the Windows-side form with
+/// `wslpath -w`: a repo on the distro's own filesystem becomes
+/// `\\wsl.localhost\<distro>\…` (which the app routes through `wsl.exe`, see
+/// `wsl.rs`), and a repo under `/mnt/c/…` becomes a plain `C:\…`. Backgrounded
+/// with `nohup … &` so the WSL terminal returns immediately, matching the native
+/// Linux launcher.
+#[cfg(any(target_os = "windows", test))]
+fn wsl_launcher(win_exe: &str) -> String {
+    let win_exe = sh_single_quote(win_exe);
+    format!(
+        r#"#!/bin/sh
+# GitCat command-line launcher for WSL. Installed by GitCat on Windows (Settings
+# > Command line, or the "Install 'gitcat' command" action) into each detected
+# WSL distro. Re-run that after moving or updating the app.
+#
+# Launches the Windows GitCat via interop, converting the repo path to the
+# Windows-side form the app understands. nohup + & so this terminal returns
+# right away.
+exe=$(wslpath -u {win_exe})
+if [ $# -eq 0 ]; then
+  nohup "$exe" >/dev/null 2>&1 &
+  exit 0
+fi
+target="$1"
+case "$target" in
+  -*) nohup "$exe" "$target" >/dev/null 2>&1 &
+      exit 0 ;;
+  *) resolved=$(cd "$target" 2>/dev/null && pwd); [ -n "$resolved" ] && target="$resolved" ;;
+esac
+win=$(wslpath -w "$target" 2>/dev/null) || win="$target"
+nohup "$exe" "$win" >/dev/null 2>&1 &
+"#
+    )
+}
+
+/// Parse the distro names out of `wsl.exe -l -q`'s output.
+///
+/// That command emits UTF-16LE (a long-standing `wsl.exe` quirk), so decode that
+/// when the bytes look like it — ASCII names show up as interleaved NUL bytes —
+/// and otherwise fall back to UTF-8 so a future UTF-8 `wsl.exe` still parses. One
+/// distro name per line; a leading BOM, stray NULs and surrounding whitespace are
+/// trimmed. `docker-desktop`/`docker-desktop-data` are Docker's service distros,
+/// not user environments, so they're dropped (VS Code skips them too). Pure, so
+/// it's unit-tested on every platform.
+#[cfg(any(target_os = "windows", test))]
+fn parse_wsl_list(raw: &[u8]) -> Vec<String> {
+    let odd_zeros = raw.iter().skip(1).step_by(2).filter(|&&b| b == 0).count();
+    let looks_utf16 = raw.len() >= 4 && odd_zeros * 4 >= raw.len();
+    let text = if looks_utf16 {
+        let u16s: Vec<u16> = raw.chunks_exact(2).map(|c| u16::from_le_bytes([c[0], c[1]])).collect();
+        String::from_utf16_lossy(&u16s)
+    } else {
+        String::from_utf8_lossy(raw).into_owned()
+    };
+    text.lines()
+        .map(|l| l.trim_matches(|c: char| c.is_whitespace() || c == '\u{feff}' || c == '\0'))
+        .filter(|l| !l.is_empty())
+        .filter(|l| {
+            let lc = l.to_ascii_lowercase();
+            lc != "docker-desktop" && lc != "docker-desktop-data"
+        })
+        .map(|l| l.to_string())
+        .collect()
 }
 
 // ── Per-platform install glue ────────────────────────────────────────────────
@@ -273,7 +355,84 @@ fn windows_install() -> Result<String, String> {
     let target = dir.join("gitcat.cmd");
     std::fs::write(&target, windows_cmd_shim(exe))
         .map_err(|e| format!("Couldn't write {}: {e}", target.display()))?;
+
+    // Best-effort: also install a Linux launcher into each detected WSL distro so
+    // `gitcat .` works from a WSL shell. WSL being absent, or a distro failing,
+    // must NOT fail the whole install — the `.cmd` above is the primary result
+    // and is what the returned path names. Outcomes are logged, not surfaced.
+    install_wsl_launchers(exe);
+
     Ok(target.display().to_string())
+}
+
+/// Install the WSL launcher (see [`wsl_launcher`]) into every detected distro's
+/// `~/.local/bin/gitcat`. Entirely best-effort: no WSL, no distros, a timeout, or
+/// a per-distro failure all just log and move on — the caller has already written
+/// the Windows `.cmd` shim, which is the primary result.
+///
+/// The launcher is staged once in a Windows temp file; each distro then reads it
+/// through its own `wslpath -u` translation and copies it into place. Going
+/// through a file (rather than piping the script on stdin) lets EVERY `wsl.exe`
+/// call here run under [`output_with_timeout`] — `wsl.exe` interop has been
+/// observed hanging forever for real users (see that helper's own doc), and an
+/// unbounded call would strand the install with the spinner up. `~/.local/bin` is
+/// on PATH by default on Debian/Ubuntu (their `~/.profile` adds it when the
+/// directory exists), so a fresh WSL shell finds it, matching the native Linux
+/// install.
+#[cfg(target_os = "windows")]
+fn install_wsl_launchers(win_exe: &str) {
+    use crate::procutil::{output_with_timeout, NoConsoleWindowExt};
+    use std::time::Duration;
+
+    // `wsl.exe -l -q` lists installed distros. Missing wsl.exe (the feature isn't
+    // installed), a non-zero exit (no distros), or a timeout => nothing to do.
+    // Generous ceiling: the WSL service can be cold on first use.
+    let mut list_cmd = std::process::Command::new("wsl.exe");
+    list_cmd.args(["-l", "-q"]).no_console_window();
+    let distros = match output_with_timeout(list_cmd, Duration::from_secs(15)) {
+        Ok(out) if out.status.success() => parse_wsl_list(&out.stdout),
+        _ => return,
+    };
+    if distros.is_empty() {
+        return;
+    }
+
+    // A fixed temp name (like macos_admin_install's own staging file) — a button
+    // click can't realistically race itself. LF is preserved (Rust's fs::write
+    // doesn't translate line endings), which matters: a CRLF shebang would make
+    // the distro reject the script with "bad interpreter".
+    let staged = std::env::temp_dir().join("gitcat-wsl-launcher");
+    if std::fs::write(&staged, wsl_launcher(win_exe)).is_err() {
+        return;
+    }
+    let staged_win = match staged.to_str() {
+        Some(s) => s,
+        None => {
+            let _ = std::fs::remove_file(&staged);
+            return;
+        }
+    };
+    // Single-quote the Windows temp path so `wslpath -u` receives it literally,
+    // whatever %TEMP% expands to.
+    let install = format!(
+        r#"mkdir -p "$HOME/.local/bin" && cp "$(wslpath -u {})" "$HOME/.local/bin/gitcat" && chmod 755 "$HOME/.local/bin/gitcat""#,
+        sh_single_quote(staged_win)
+    );
+    for distro in &distros {
+        let mut cmd = std::process::Command::new("wsl.exe");
+        // Uniform &str elements: distro/install are String, the rest are literals.
+        cmd.args(["-d", distro.as_str(), "-e", "sh", "-c", install.as_str()])
+            .no_console_window();
+        match output_with_timeout(cmd, Duration::from_secs(20)) {
+            Ok(out) if out.status.success() => eprintln!("gitcat: installed the WSL launcher into {distro}"),
+            Ok(out) => eprintln!(
+                "gitcat: couldn't install the WSL launcher into {distro}: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+            Err(e) => eprintln!("gitcat: couldn't install the WSL launcher into {distro}: {e}"),
+        }
+    }
+    let _ = std::fs::remove_file(&staged);
 }
 
 #[cfg(test)]
@@ -341,5 +500,48 @@ mod tests {
         // doubled so `start` still receives the real path.
         let s = windows_cmd_shim(r"C:\100%\gitcat.exe");
         assert!(s.contains(r#""C:\100%%\gitcat.exe""#));
+    }
+
+    #[test]
+    fn wsl_launcher_translates_paths_and_backgrounds() {
+        let s = wsl_launcher(r"C:\Program Files\GitCat\gitcat.exe");
+        assert!(s.starts_with("#!/bin/sh"));
+        // The exe path is single-quoted (spaces/metacharacters kept literal) and
+        // translated to the distro's own mount point at run time.
+        assert!(s.contains(r#"exe=$(wslpath -u 'C:\Program Files\GitCat\gitcat.exe')"#));
+        // The repo argument is converted to the Windows-side path the app expects.
+        assert!(s.contains(r#"win=$(wslpath -w "$target""#));
+        // Non-blocking: the WSL terminal returns right away.
+        assert!(s.contains("nohup \"$exe\""));
+    }
+
+    #[test]
+    fn wsl_launcher_neutralizes_shell_metacharacters_in_the_exe_path() {
+        // A `$` in the baked path must stay literal — single quotes see to that.
+        let s = wsl_launcher(r"C:\weird$name\gitcat.exe");
+        assert!(s.contains(r#"wslpath -u 'C:\weird$name\gitcat.exe'"#));
+    }
+
+    #[test]
+    fn parse_wsl_list_decodes_utf16le_and_filters_service_distros() {
+        // `wsl.exe -l -q` emits UTF-16LE; docker's service distros are dropped.
+        let raw: Vec<u8> = "Ubuntu\r\ndocker-desktop\r\nDebian\r\ndocker-desktop-data\r\n"
+            .encode_utf16()
+            .flat_map(|u| u.to_le_bytes())
+            .collect();
+        assert_eq!(parse_wsl_list(&raw), vec!["Ubuntu".to_string(), "Debian".to_string()]);
+    }
+
+    #[test]
+    fn parse_wsl_list_strips_a_utf16_bom() {
+        let raw: Vec<u8> = "\u{feff}Ubuntu\r\n".encode_utf16().flat_map(|u| u.to_le_bytes()).collect();
+        assert_eq!(parse_wsl_list(&raw), vec!["Ubuntu".to_string()]);
+    }
+
+    #[test]
+    fn parse_wsl_list_empty_and_utf8_fallback() {
+        assert!(parse_wsl_list(&[]).is_empty());
+        // A defensive UTF-8 fallback for a hypothetical future non-UTF-16 wsl.exe.
+        assert_eq!(parse_wsl_list(b"Ubuntu\nDebian\n"), vec!["Ubuntu".to_string(), "Debian".to_string()]);
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -78,6 +78,33 @@ fn window_url(arg: &InitialArg) -> WebviewUrl {
 /// resolves to a real git repo is `Repo`; one that exists but isn't a repo, or
 /// can't be resolved at all, is `NotRepo` so the user is told rather than left
 /// staring at a window that silently opened nothing.
+/// Turn a Windows extended-length "verbatim" path back into its ordinary form.
+///
+/// `std::fs::canonicalize` on Windows always returns a verbatim path: a normal
+/// drive path comes back as `\\?\C:\…`, and a UNC/network/WSL share as
+/// `\\?\UNC\server\share\…`. That prefix is valid for the Win32 file APIs, but
+/// almost everything downstream expects the plain form: libgit2's own path
+/// splitting, `git.exe -C`, the `\\wsl.localhost\…` detector in `wsl.rs`, the
+/// repo registry's path-equality checks, and the path shown in the UI. The GUI
+/// never produces a verbatim path (it opens absolute paths as-is), so a
+/// `gitcat .`-style relative launch — the one code path that runs through
+/// `canonicalize` — was the only way one ever reached the app.
+///
+/// Maps `\\?\UNC\server\share` back to `\\server\share` (so a WSL repo becomes
+/// the `\\wsl.localhost\<distro>\…` form `wsl::wsl_target` understands) and
+/// `\\?\C:\…` back to `C:\…`. A path without the prefix (every non-Windows
+/// path, and any already-plain input) is returned untouched, so this is safe to
+/// call unconditionally. Pure string work, unit-tested on every platform.
+fn strip_windows_verbatim_prefix(p: String) -> String {
+    if let Some(rest) = p.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{rest}")
+    } else if let Some(rest) = p.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        p
+    }
+}
+
 fn classify_initial_arg(raw: Option<String>) -> InitialArg {
     let raw = match raw {
         Some(r) if !r.is_empty() && !r.starts_with('-') => r,
@@ -89,8 +116,16 @@ fn classify_initial_arg(raw: Option<String>) -> InitialArg {
         // Relative: resolve against the CWD. canonicalize requires the path to
         // exist, so a bogus relative arg falls through to the NotRepo hint with
         // its original text (the most useful thing to show the user).
+        //
+        // On Windows canonicalize returns an extended-length "verbatim" path
+        // (`\\?\C:\…`); strip that prefix back to the ordinary form the rest of
+        // the app expects (see `strip_windows_verbatim_prefix`). Without this,
+        // `gitcat .` opened a `\\?\C:\…` repo that libgit2 mishandled and the
+        // graph came up blank — while `gitcat C:\abs\path` (kept verbatim above,
+        // never canonicalized) and every GUI open worked, since only a relative
+        // arg reaches canonicalize.
         match std::fs::canonicalize(&raw).ok().and_then(|p| p.to_str().map(str::to_string)) {
-            Some(a) => a,
+            Some(a) => strip_windows_verbatim_prefix(a),
             None => return InitialArg::NotRepo(raw),
         }
     };
@@ -277,6 +312,26 @@ mod tests {
     fn not_repo_for_a_missing_absolute_path() {
         let missing = unique_tmp("missing").to_str().unwrap().to_string();
         assert!(matches!(classify_initial_arg(Some(missing.clone())), InitialArg::NotRepo(p) if p == missing));
+    }
+
+    #[test]
+    fn verbatim_prefix_stripped_to_ordinary_form() {
+        // A drive-letter verbatim path (what `gitcat .` produced on Windows,
+        // and the reason the graph came up blank) collapses to the plain path.
+        assert_eq!(strip_windows_verbatim_prefix(r"\\?\C:\Users\me\proj".into()), r"C:\Users\me\proj");
+        // A UNC/WSL share verbatim path collapses to the `\\host\…` form that
+        // wsl::wsl_target recognizes, so `gitcat .` inside a WSL directory opens
+        // the right repo instead of a mangled one.
+        assert_eq!(
+            strip_windows_verbatim_prefix(r"\\?\UNC\wsl.localhost\Ubuntu\home\me\proj".into()),
+            r"\\wsl.localhost\Ubuntu\home\me\proj"
+        );
+        assert_eq!(strip_windows_verbatim_prefix(r"\\?\UNC\server\share\dir".into()), r"\\server\share\dir");
+        // Anything without the prefix (every Unix path, any already-plain input)
+        // is returned untouched — safe to call unconditionally.
+        assert_eq!(strip_windows_verbatim_prefix("/home/me/proj".into()), "/home/me/proj");
+        assert_eq!(strip_windows_verbatim_prefix(r"C:\already\plain".into()), r"C:\already\plain");
+        assert_eq!(strip_windows_verbatim_prefix(r"\\wsl.localhost\Ubuntu\x".into()), r"\\wsl.localhost\Ubuntu\x");
     }
 
     #[test]


### PR DESCRIPTION
Two Windows fixes for the `gitcat` command-line launcher.

## 1. `gitcat .` opened a repo with a blank graph

`gitcat .` passes a relative arg (`.`), which `classify_initial_arg` resolves with `std::fs::canonicalize`. On Windows that always returns an extended-length **verbatim** path (`\\?\C:\...`). That prefix flowed straight into `?repo=` and on to `load_graph`'s libgit2 open, which mishandles it: the repo appeared to open (window was interactive) but the commit graph rendered blank.

Only relative CLI args hit this. `gitcat C:\abs\path` is kept verbatim (never canonicalized), and every GUI open already passes a plain absolute path, which is why the bug was specific to `gitcat .`. `cli_shim.rs` already documents the same `\\?\` hazard for the shim's own exe path; this closes the matching gap on the launch-arg side.

**Fix:** normalize the canonicalized result back to the ordinary form via a pure, unit-tested helper (`\\?\UNC\server\share` -> `\\server\share`, `\\?\C:\...` -> `C:\...`). Mapping the UNC case to `\\host\...` also produces the `\\wsl.localhost\<distro>\...` shape `wsl::wsl_target` recognizes. No-op on any path without the prefix.

## 2. `gitcat .` from inside a WSL shell

The Windows `.cmd` shim can't be executed from a WSL shell (interop only runs PE binaries, not batch files), so `gitcat .` from a WSL terminal did nothing.

**Fix:** when Install 'gitcat' command runs on Windows, it now also best-effort installs a native Linux launcher into every detected WSL distro (`~/.local/bin/gitcat`). That launcher converts the repo path with `wslpath -w` and hands the resulting `\\wsl.localhost\<distro>\...` path to the Windows app, which already routes a WSL repo through the distro's own git (see `wsl.rs`). It backgrounds with `nohup ... &` so the terminal returns right away.

Design notes:
- The launcher is staged once in a Windows temp file; each distro reads it through its own `wslpath -u` translation and `cp`s it into place. Going through a file (rather than piping on stdin) lets every `wsl.exe` call run under `procutil::output_with_timeout` — `wsl.exe` interop has hung forever for real users before, and an unbounded call would strand the install with the spinner up.
- `docker-desktop`/`docker-desktop-data` service distros are skipped (VS Code skips them too).
- WSL being absent, a timeout, or a single distro failing is not an error: the Windows `.cmd` is the primary result and is what the reported install path names, so a non-WSL machine is unaffected.

## Tests / verification

- New pure helpers are unit-tested on every platform: `strip_windows_verbatim_prefix` (windows.rs), and `wsl_launcher` + `parse_wsl_list` (cli_shim.rs, including UTF-16LE decoding of `wsl.exe -l -q`, BOM stripping, and service-distro filtering).
- Full Rust lib suite green locally (256 passed); macOS build warning-clean.
- The Windows-only install glue compiles on CI via the `rust-windows` job.

Note: the WSL install path can't be exercised from the macOS dev box; the pure builders are covered by unit tests and the glue follows the existing `cli_shim.rs` platform-split conventions. Surfacing per-distro WSL results in the UI (currently logged) is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)