### PR TITLE
release: GitCat 1.1.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,7 +17,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gitcat";
-  version = "1.0.0";
+  version = "1.1.0";
 
   inherit src;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitcat",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "pnpm@10.34.5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "gitcat"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "base64 0.22.1",
  "console-subscriber",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitcat"
-version = "1.0.0"
+version = "1.1.0"
 description = "A cozy, safety-first desktop Git client."
 authors = ["Jiucheng Zang <git.jiucheng@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GitCat",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.jiucheng.gitcat",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump to **1.1.0** across the five files the v1.0.0 release touched: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, and `nix/package.nix`. No code changes.

Cutting the release: once this merges to `main`, pushing the tag **`v1.1.0`** triggers `release.yml` (builds all 6 platform/arch bundles and creates a draft GitHub Release for the tag).

## What's in 1.1.0 (since v1.0.0)
- **Plugin system** — registry + executor, ⌘K commands, hooks, declarative panels, Tama reactions/skins, named external tools.
- **Chinese (zh) i18n** — full UI + backend-message localization with live language switch; English stays the source of truth (see `CONTRIBUTING.md`).
- **Inline graph ref labels** (#18) — chips before the subject, with a Graph label-layout setting.
- **`gitcat` CLI launcher** — install a `code .`-style command (macOS/Linux/Windows), including a WSL launcher.
- Plus the graph/history, working-directory, and Safety-Manager work merged over the cycle.

Cargo.lock verified in sync at 1.1.0 (`cargo metadata --locked`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)