### PR TITLE
ci: auto back-merge main into dev (Option A)

### DIFF
--- a/.github/workflows/backmerge-dev.yml
+++ b/.github/workflows/backmerge-dev.yml
@@ -1,0 +1,70 @@
+name: Back-merge main into dev
+
+# Keeps dev in sync with main automatically (releases, hotfixes) without anyone
+# opening or clicking a PR by hand. On every push to main, this opens (or reuses)
+# a main -> dev pull request and turns on auto-merge, so it lands on its own once
+# dev's required checks pass. dev stays protected and CI-gated the whole time.
+#
+# SETUP REQUIRED (one time — see the PR description):
+#   1. Repo Settings > General > Pull Requests > enable "Allow auto-merge".
+#   2. Add a secret BACKMERGE_TOKEN — a PAT (repo scope) or GitHub App token.
+#      The DEFAULT GITHUB_TOKEN will NOT work here: a PR opened by GITHUB_TOKEN
+#      does not trigger CI, so dev's required checks would never run and
+#      auto-merge could never complete. A PAT-opened PR triggers CI normally.
+#   3. Make sure dev's branch protection requires the CI checks (so auto-merge
+#      waits for them) and does not require a human approval it can't get.
+on:
+  push:
+    branches: [main]
+
+# Only needs to open/merge PRs; the actual merge into protected dev goes through
+# GitHub's merge (respecting branch protection), not a raw push.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize runs so two quick pushes to main can't race on the same PR.
+concurrency:
+  group: backmerge-dev
+  cancel-in-progress: false
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open (or reuse) the main->dev PR and enable auto-merge
+        env:
+          # See SETUP note above — this MUST be a PAT/App token, not GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Nothing to sync? (dev already contains everything on main) — done.
+          ahead="$(gh api "repos/$REPO/compare/dev...main" --jq '.ahead_by')"
+          if [ "$ahead" -eq 0 ]; then
+            echo "dev already up to date with main; nothing to back-merge."
+            exit 0
+          fi
+          echo "main is $ahead commit(s) ahead of dev."
+
+          # Reuse the existing open back-merge PR if there is one (a main->dev PR
+          # picks up new commits on its own); otherwise open a fresh one.
+          num="$(gh pr list --base dev --head main --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$num" ]; then
+            echo "Reusing existing PR #$num."
+          else
+            url="$(gh pr create --base dev --head main \
+              --title "chore: back-merge main into dev" \
+              --body "Automated sync so dev doesn't drift from main (releases, hotfixes). Auto-merges once dev's required checks pass. Opened by the back-merge-dev workflow.")"
+            num="$(printf '%s\n' "$url" | grep -oE '[0-9]+$')"
+            echo "Opened PR #$num ($url)."
+          fi
+
+          # Turn on auto-merge (merge commit, so dev stays a true superset of
+          # main's history). Lands automatically once required checks pass; if a
+          # conflict or a missing check blocks it, the PR just stays open for a
+          # human. A non-zero here (e.g. "Allow auto-merge" is off) is surfaced
+          # but not fatal — the PR is already open either way.
+          gh pr merge "$num" --auto --merge \
+            || echo "::warning::Could not enable auto-merge on PR #$num — check that 'Allow auto-merge' is on and dev's protection permits it. The PR is open; merge it manually if needed."


### PR DESCRIPTION
Adds `.github/workflows/backmerge-dev.yml` so `dev` stays in sync with `main` (releases, hotfixes) **without opening a PR by hand**. On every push to `main` it opens (or reuses) a `main → dev` PR and enables **auto-merge**, so it lands on its own once `dev`'s required checks pass. `dev` stays protected and CI-gated.

## One-time setup (required for it to actually work)
1. **Settings → General → Pull Requests → enable "Allow auto-merge".**
2. **Add a repo secret `BACKMERGE_TOKEN`** — a PAT (classic: `repo` scope; or fine-grained: this repo, Contents RW + Pull requests RW), or a GitHub App token.
   - Why not the default `GITHUB_TOKEN`? A PR opened by `GITHUB_TOKEN` does **not** trigger CI, so `dev`'s required checks would never run and auto-merge could never complete. A PAT-opened PR triggers CI normally.
3. **Check `dev`'s branch protection**: require the CI checks (so auto-merge waits for them), and make sure it doesn't require a human approval the bot can't provide (a solo-maintainer setup usually just requires checks).

## Behavior notes
- If `main` and `dev` are already in sync, it exits quietly (no empty PR).
- If a back-merge PR is already open, it's reused (a `main→dev` PR picks up new commits automatically).
- Merge strategy is a **merge commit**, so `dev` stays a true superset of `main`'s history.
- On a conflict, or if auto-merge can't be enabled, the PR just stays open for a human — nothing is force-pushed.
- No recursion: it triggers only on push to `main`; merging into `dev` doesn't re-trigger it.

Once this is merged to `main` and the secret/setting are in place, it's active on the next push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)