### PR TITLE
Translate the pinned Uncommitted-changes band (English in every locale today)

### DIFF
--- a/e2e/band-i18n.spec.ts
+++ b/e2e/band-i18n.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// The pinned "Uncommitted changes" band is CANVAS text — no node, no accessible
+// name — which is how it stayed hardcoded English through every locale the app
+// shipped without anyone noticing. It is still reachable: hash the pixels of the
+// row it occupies and check they change with the language.
+//
+// Read from the backing store rather than page.screenshot, because a screenshot
+// physically cannot see the badge: the dev perf HUD is absolutely positioned
+// over the canvas's top-right corner, exactly where the badge is right-aligned,
+// and rewrites its fps readout several times a second. getImageData sees the
+// canvas alone.
+//
+// The assertion is "the hash changes", never "the hash is <value>". A golden
+// number here would break on any font, theme or antialiasing change and teach
+// everyone to delete it.
+//
+// The row is hashed in two halves and BOTH are asserted, because the band draws
+// two independent strings: the label on the left, the status badge right-
+// aligned at W-14. One whole-row hash is satisfied by either one changing, which
+// is not the guarantee this test is for.
+//
+// That split has less headroom than it looks. By the time of the comparison the
+// badge reads "1 staged · 2 unstaged" rather than "clean", so its ink starts
+// around x375 against a midpoint near x313 — roughly 60px, not the ~250 the
+// short badge would suggest. A verbose translation of staged_unstaged is what
+// erodes it first (the English string alone spans ~236px); a much narrower
+// canvas would do it too. Either way the badge crosses into the left half and
+// the two-half split quietly degenerates into the whole-row hash it replaced.
+//
+// WHAT THIS DOES NOT COVER: workdir.n_conflicted — the demo status is fixed at
+// conflicted:0, so that branch needs a real repo in a conflicted state. And
+// workdir.clean is drawn once, in English, before the band is selected below —
+// never in zh, and never inside an assertion.
+
+// Source of truth is ROW_H_BASE in src/legacy/main.ts; the band is exactly one
+// row at zoom 1. Nothing ties these together, so a change there silently makes
+// this hash the wrong strip and click at the wrong y.
+const BAND_CSS_H = 26;
+const POLL_MS = 150;
+const POLL_N = 40;
+
+async function bandStats(page: Page) {
+  return page.evaluate((cssH) => {
+    const c = document.getElementById("cv") as HTMLCanvasElement;
+    // Derive DPR from the backing store rather than window.devicePixelRatio, so
+    // this still lines up when the renderer drops resolution mid-scroll.
+    const dpr = c.width / c.getBoundingClientRect().width;
+    const rows = Math.round(cssH * dpr);
+    const d = c.getContext("2d")!.getImageData(0, 0, c.width, rows).data;
+    const mid = Math.floor(c.width / 2);
+    let left = 0, right = 0;
+    const leftInk = new Set<string>(), rightInk = new Set<string>();
+    for (let y = 0; y < rows; y++) {
+      for (let x = 0; x < c.width; x++) {
+        const i = (y * c.width + x) * 4;
+        const px = d[i] + d[i + 1] * 7 + d[i + 2] * 13;
+        if (x < mid) { left = (left * 31 + px) >>> 0; leftInk.add(d[i] + "," + d[i + 1] + "," + d[i + 2]); }
+        else { right = (right * 31 + px) >>> 0; rightInk.add(d[i] + "," + d[i + 1] + "," + d[i + 2]); }
+      }
+    }
+    return { left, right, leftInk: leftInk.size, rightInk: rightInk.size };
+  }, BAND_CSS_H);
+}
+
+type BandStats = Awaited<ReturnType<typeof bandStats>>;
+
+// Poll until two consecutive reads are identical — "the renderer has stopped
+// changing".
+async function settledBand(page: Page) {
+  const seen: BandStats[] = [await bandStats(page)];
+  for (let i = 0; i < POLL_N; i++) {
+    await page.waitForTimeout(POLL_MS);
+    const cur = await bandStats(page);
+    const prev = seen[seen.length - 1];
+    seen.push(cur);
+    if (cur.left === prev.left && cur.right === prev.right) return cur;
+  }
+  throw new Error(
+    `band never settled in ${(POLL_MS * POLL_N) / 1000}s — last three reads ${JSON.stringify(seen.slice(-3))}`,
+  );
+}
+
+test("the pinned band's text follows the locale, live", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  // Design mode: workdirAvailable() is true without Tauri, so the band draws
+  // over the synthetic demo graph — no repo fixture and nothing locale-coupled
+  // to click through.
+  await page.goto("/");
+  await expect(page.locator("#cv")).toBeVisible();
+  // Design mode opens the setup wizard unconditionally and its scrim covers the
+  // canvas, so the band click below would land on the scrim instead. Esc is the
+  // app's own way out — same idiom as ref-folder-tree.spec.ts.
+  await page.keyboard.press("Escape");
+  // toBeHidden, not "class no longer has .on" — .scrim delays its visibility
+  // flip (`transition: … visibility 0s linear .16s`), so for that window the
+  // class is already off while the element still covers the canvas and eats the
+  // click. Losing the click is silent: the band never gets selected and the
+  // badge quietly stays on workdir.clean.
+  await expect(page.locator("#setupWizardScrim")).toBeHidden();
+  // Let the canvas finish painting before taking coordinates off it.
+  await settledBand(page);
+
+  // Selecting the band loads the demo working-tree status, which moves the
+  // badge off workdir.clean and onto staged_unstaged — the key that carries
+  // placeholders, where a dropped {staged} would still read like a sentence.
+  // Any x inside the row selects it; 120 is just clear of the dot.
+  const box = (await page.locator("#cv").boundingBox())!;
+  await page.mouse.click(box.x + 120, box.y + BAND_CSS_H / 2);
+  // Park the pointer off the canvas and leave it there. The band's hover tint
+  // is a fillRect across the WHOLE row, so a pointer that enters or leaves the
+  // row between the two captures changes both halves for a reason that has
+  // nothing to do with language — the attribution this test exists to make.
+  // selectOption and Escape below do not move it; keep it that way.
+  await page.mouse.move(box.x - 5, box.y - 5);
+  // Wait for the status to actually arrive before the first capture, because
+  // the badge repaint is asynchronous and the settle poll cannot tell "not
+  // repainted yet" from "finished": capturing EN with the old `clean` badge and
+  // ZH with the new one makes both halves differ whether or not anything is
+  // translated. Found exactly that way — without this line, reverting
+  // staged_unstaged to hardcoded English still passed.
+  //
+  // It is also the only proof that the click landed on the band at all. If it
+  // missed, the badge stays on workdir.clean — which still translates — so both
+  // halves still differ and this test goes green having covered none of the
+  // above. Replacing this with a sleep turns a loud failure into a silent one.
+  await expect(page.locator("#detail")).toContainText(/\d+ staged/);
+
+  const en = await settledBand(page);
+  // Narrow but real: catches a capture taken before the canvas' first paint,
+  // where an all-background row would make both later comparisons meaningless.
+  // It is NOT a missing-text detector: the left half holds the band's accent dot
+  // whenever the band draws at all, and the right half holds the scrollbar
+  // whenever there is one (scrollbarGeom returns null on a short graph) — so a
+  // half can clear this with no text in it.
+  expect(en.leftInk, "canvas looks unpainted — captured before the first frame?").toBeGreaterThan(3);
+  expect(en.rightInk, "canvas looks unpainted — captured before the first frame?").toBeGreaterThan(3);
+
+  // Switch language the way a user does, which also exercises legacy/main.ts's
+  // i18nEvents "change" handler — its own comment promises the canvas repaints
+  // on a switch. The locale picker has no id or test id, and Settings renders a
+  // dozen selects, so it is identified by the option it contains.
+  await page.keyboard.press("Control+,");
+  await expect(page.locator(".modal.settings")).toBeVisible();
+  await page.locator('.modal.settings select:has(option[value="zh"])').selectOption("zh");
+  await page.keyboard.press("Escape");
+
+  const zh = await settledBand(page);
+  expect(zh.left, "the band's LABEL is pixel-identical in en and zh — it is not going through t()").not.toBe(en.left);
+  expect(zh.right, "the band's BADGE is pixel-identical in en and zh — it is not going through t()").not.toBe(en.right);
+
+  expect(errors).toEqual([]);
+});

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -37,6 +37,36 @@ import { t, be, locale, i18nEvents } from "@/i18n/i18n.svelte.ts";
 "use strict";
 const $=(s,r=document)=>r.querySelector(s), $$=(s,r=document)=>[...r.querySelectorAll(s)];
 const TAU=Math.PI*2;
+// No fallback needed here: a rendered element's resolved fontFamily is never
+// empty. FONT_MONO below is a different case — see its note.
+const FONT_UI=getComputedStyle(document.body).fontFamily;
+// The canvas's fixed-width face, read from the SAME --mono the DOM uses rather
+// than hardcoded separately at each call site below, so the graph and the DOM
+// diff view stop disagreeing about what "monospace" means.
+//
+// The fallback is not belt-and-braces: an empty custom property composes to
+// "11px ", which a canvas rejects SILENTLY — ctx.font keeps whatever was set
+// last, so the sha would quietly render in the UI face with nothing thrown.
+//
+// Read ONCE, at module load. That is safe only while --mono stays a single
+// unscoped declaration: this const sits outside readTheme()'s re-read path, and
+// a language switch only repaints. Scoping --mono per theme or per locale means
+// re-reading it here too.
+//
+// A consistency fix, not a coverage one — as long as --mono names no CJK or
+// Hangul family (it doesn't today), non-Latin glyphs come from Blink's
+// per-character system fallback regardless; measured, 个 is the same width under
+// the old stack, the new one, and a deliberately nonexistent family. Adding one
+// would change that, and this note with it.
+//
+// Not free, either: wherever the named faces are installed, the sha column
+// moves off the generic monospace face onto the first of them and gets slightly
+// wider. That is every stock Windows box (Windows Terminal ships Cascadia
+// Code), and any Linux box carrying cascadia-code or the MS core fonts; macOS
+// resolved ui-monospace to SF Mono under the old stack already, so it is
+// unchanged. AUTHOR_GUTTER reserves enough for the wider sha — nothing
+// collides — but it is a visible restyle, not a no-op.
+const FONT_MONO=getComputedStyle(document.documentElement).getPropertyValue("--mono").trim()||"ui-monospace,monospace";
 const app=$("#app");
 
 /* Painted Tama art (Nano-Banana / Gemini), embedded as WebP data URIs.
@@ -603,7 +633,7 @@ function renderContent(st, rowLo, rowHi, strip){
       let s=msgOf(r); if(s.length>LABEL_MAX) s=s.slice(0,LABEL_MAX); const maxw=W-cx-AUTHOR_GUTTER;
       if(ctx.measureText(s).width>maxw){while(s.length>4&&ctx.measureText(s+"…").width>maxw)s=s.slice(0,-1);s+="…";}
       ctx.fillText(s,cx,y);
-      ctx.fillStyle=theme.muted; ctx.textAlign="right"; ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px ui-monospace,monospace";
+      ctx.fillStyle=theme.muted; ctx.textAlign="right"; ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px "+FONT_MONO;
       const sha=hhex(r), shaW=ctx.measureText(sha).width;
       // Author preview — right next to the sha, so who wrote a commit is
       // visible at a glance without opening its detail panel. Own (slightly
@@ -613,7 +643,11 @@ function renderContent(st, rowLo, rowHi, strip){
       let a=authorOf(r); if(a.length>LABEL_MAX) a=a.slice(0,LABEL_MAX); const maxAuthorW=AUTHOR_GUTTER-96-8;
       if(ctx.measureText(a).width>maxAuthorW){while(a.length>1&&ctx.measureText(a+"…").width>maxAuthorW)a=a.slice(0,-1);a+="…";}
       ctx.fillText(a,W-14-shaW-8,y);
-      ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px ui-monospace,monospace";
+      // Back to mono. Not a duplicate of the line above the author preview —
+      // that preview clobbered ctx.font with FONT_UI, and without restoring it
+      // the sha draws in the UI face. Silently: a canvas never complains about
+      // the font it was handed.
+      ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px "+FONT_MONO;
       ctx.fillText(sha,W-14,y); ctx.textAlign="left";
     }
     ctx.globalAlpha=1;
@@ -758,7 +792,7 @@ function drawWorkdirBand(){
   const badge=nConflict?t("workdir.n_conflicted",{n:nConflict})
     :(nStaged||nUnstaged)?t("workdir.staged_unstaged",{staged:nStaged,unstaged:nUnstaged})
     :t("workdir.clean");
-  ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px ui-monospace,monospace";
+  ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px "+FONT_MONO;
   ctx.fillStyle=nConflict?theme.danger:theme.muted; ctx.textAlign="right";
   ctx.fillText(badge,W-14,y); ctx.textAlign="left";
   ctx.strokeStyle=theme.border; ctx.lineWidth=1;

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -37,7 +37,6 @@ import { t, be, locale, i18nEvents } from "@/i18n/i18n.svelte.ts";
 "use strict";
 const $=(s,r=document)=>r.querySelector(s), $$=(s,r=document)=>[...r.querySelectorAll(s)];
 const TAU=Math.PI*2;
-const FONT_UI=getComputedStyle(document.body).fontFamily;
 const app=$("#app");
 
 /* Painted Tama art (Nano-Banana / Gemini), embedded as WebP data URIs.
@@ -753,10 +752,12 @@ function drawWorkdirBand(){
   else if(hover){ ctx.beginPath(); ctx.arc(x,y,dotR+2.6,0,TAU); ctx.strokeStyle=theme.muted; ctx.lineWidth=1; ctx.stroke(); }
   ctx.textBaseline="middle"; ctx.textAlign="left";
   ctx.font=Math.round(12.5*Math.min(1.25,layout.zoom))+"px "+FONT_UI; ctx.fillStyle=theme.text;
-  ctx.fillText("Uncommitted changes",x+dotR+14,y);
+  ctx.fillText(t("workdir.uncommitted_changes"),x+dotR+14,y);
   const s=workdirCtrl.status;
   const nConflict=s?s.conflicted:0, nStaged=s?s.staged.length:0, nUnstaged=s?s.unstaged.length:0;
-  const badge=nConflict?(nConflict+" conflicted"):(nStaged||nUnstaged)?(nStaged+" staged · "+nUnstaged+" unstaged"):"clean";
+  const badge=nConflict?t("workdir.n_conflicted",{n:nConflict})
+    :(nStaged||nUnstaged)?t("workdir.staged_unstaged",{staged:nStaged,unstaged:nUnstaged})
+    :t("workdir.clean");
   ctx.font=Math.round(10.5*Math.min(1.2,layout.zoom))+"px ui-monospace,monospace";
   ctx.fillStyle=nConflict?theme.danger:theme.muted; ctx.textAlign="right";
   ctx.fillText(badge,W-14,y); ctx.textAlign="left";


### PR DESCRIPTION
# The pinned "Uncommitted changes" band was never translated

> **Base branch:** `dev` · Branch: `fix/canvas-band-i18n`

Found while starting work on a Korean locale, but it isn't a Korean problem — **中文 has it today.**

## The bug

The band pinned across the top of the graph draws hardcoded English:

```js
ctx.fillText("Uncommitted changes", x+dotR+14, y);
const badge = nConflict ? (nConflict+" conflicted")
            : (nStaged||nUnstaged) ? (nStaged+" staged · "+nUnstaged+" unstaged")
            : "clean";
```

The keys already exist, and `Workdir.svelte` already uses them — `workdir.uncommitted_changes`, `n_conflicted`, `staged_unstaged`, `clean`. Only this canvas copy bypasses `t()`. So the most prominent row in the app stays English in every locale, right above a fully translated graph.

Four call sites, no new strings, same branch order. One small consequence worth naming: the `·` separator moves out of a JS literal into the locale strings, so it becomes a translator's choice — `zh` keeps it.

Nothing else was needed to make a live language switch work. `drawWorkdirBand` runs from `present()`, outside the blit buffer, so the scroll fast-path can't leave stale English pixels behind, and the `dirty=true` your `i18nEvents` handler already sets brings it straight back.

## A test for canvas text

The band is pixels — no node, no accessible name. That's precisely how it stayed English through every locale you've shipped without anyone noticing, so it seemed worth leaving something behind that would notice next time.

`e2e/band-i18n.spec.ts` hashes the band's row out of the canvas backing store and asserts it changes with the language, switching through the Settings picker rather than a test hook. That also exercises the live-switch path your `i18nEvents` handler promises in its own comment — as far as I could tell, nothing was covering it.

A few decisions in there that aren't obvious:

- **It reads `getImageData`, not a screenshot.** A screenshot physically cannot see the badge: the dev perf HUD is positioned over the canvas's top-right corner, exactly where the badge is right-aligned, and rewrites its fps readout several times a second.
- **The row is hashed in two halves and both are asserted.** The label is on the left, the badge on the right; one whole-row hash is satisfied by either one changing. I only found that out by reverting the badge alone and watching a single-hash version pass.
- **It never asserts a specific hash value.** A golden number would break on any font, theme or antialiasing change, and everyone would learn to delete the test.

Two things bit me while writing it, both of which made a broken build pass green, so they're commented in place:

- `.scrim` delays its visibility flip by 160ms (`transition: … visibility 0s linear .16s`). Waiting on the class rather than on `toBeHidden()` silently loses the click that follows — the band just never gets selected.
- The badge repaint is asynchronous. Capturing EN with the old badge and ZH with the new one makes both halves differ whether or not anything is translated.

What it still doesn't reach is `workdir.n_conflicted` — the demo status is fixed at `conflicted: 0`, so that branch needs a real repo in a conflicted state. That's stated in the file rather than left for someone to discover.

## Second commit: the canvas couldn't see `--mono`

Separate commit, and separable — the translation doesn't depend on it. Three canvas sites hardcoded `"…px ui-monospace,monospace"` while the DOM reads `var(--mono)`, so the graph and the diff view could disagree about what "monospace" means. They now share one constant read from the same variable.

**This one has a visible effect and I'd rather flag it than have you find it.** Wherever the named faces are actually installed, the sha column moves off the generic monospace face onto the first of them and gets slightly wider — that's every stock Windows box (Windows Terminal ships Cascadia Code) and any Linux box carrying `cascadia-code` or the MS core fonts. macOS already resolved `ui-monospace` to SF Mono, so it's unchanged. `AUTHOR_GUTTER` reserves comfortably more than the wider sha, so nothing collides, but it is a restyle rather than a no-op. **Happy to drop this commit if you'd rather not take it** — the first one stands alone.

I originally justified it as CJK coverage. That was wrong and I want to correct it rather than let it sit in a commit message: `--mono` names no CJK family, and Blink's per-character system fallback draws those either way — 个 measures the same under the old stack, the new one, and a deliberately nonexistent family. Naming the stack decides *which* face draws non-Latin text, not whether it draws.

## Two things I noticed but did not touch

- **`FONT_MONO` is read once at module load.** Fine today, since `--mono` is one unscoped declaration — but it sits outside `readTheme()`'s re-read path, so scoping `--mono` per theme or per locale would need a re-read there. The comment says so. It's also the only thing standing between this codebase and a user-selectable font, if that's ever of interest: `main.ts`'s locale handler already forces the repaint, so it's the read that would need to move, not the plumbing.
- **`src/legacy/sound.test.ts` looks flaky**, independent of this branch. On a pristine `dev` it failed once in three full-suite runs — same two tests, the first timing out inside `await import("./sound.ts")` rather than on an assertion. Not touched here; mentioning it in case it's been showing up in CI.

## Testing

`svelte-check` clean (534 files) · vitest 1405 · `vite build` · Playwright 13/13.

Each half of the new test was verified by injecting its regression separately: re-hardcoding the label fails on `LABEL`, re-hardcoding `staged_unstaged` fails on `BADGE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
