### PR TITLE
fix: search and copy the full commit hash, not just the short one (#43)

### DIFF
--- a/src/i18n/locales/en/detail.ts
+++ b/src/i18n/locales/en/detail.ts
@@ -16,7 +16,7 @@ export default {
   loading: "loading…",
   show_less: "Show less",
   show_more: "Show more",
-  click_to_copy: "Click to copy",
+  click_to_copy: "Click to copy the full hash",
   copied: "copied ✓",
   row_of: "row {row} / {total}",
   cant_revert_merge: "Can't revert a merge commit",

--- a/src/i18n/locales/zh/detail.ts
+++ b/src/i18n/locales/zh/detail.ts
@@ -16,7 +16,7 @@ export default {
   loading: "加载中…",
   show_less: "收起",
   show_more: "展开",
-  click_to_copy: "点击复制",
+  click_to_copy: "点击复制完整哈希",
   copied: "已复制 ✓",
   row_of: "第 {row} / {total} 行",
   cant_revert_merge: "无法回退一个合并 commit",

--- a/src/islands/cmdk/cmdk.svelte.test.ts
+++ b/src/islands/cmdk/cmdk.svelte.test.ts
@@ -127,6 +127,19 @@ describe("filter", () => {
     expect((cmdkCtrl.results[0] as any).subject).toBe("Add rate limiting");
   });
 
+  it("matches a commit by its FULL 40-char hash, not just the short prefix (#43)", () => {
+    const full = "bbb2222abcdef0123456789abcdef0123456789a"; // 40 chars; short is bbb2222
+    setBackendGraph([
+      { sha: "aaa1111", subject: "Fix off-by-one bug", an: { n: "Dev" }, refs: [] },
+      { sha: "bbb2222", subject: "Add rate limiting", an: { n: "Dev" }, refs: [] },
+    ]);
+    (bridge as any).BACKEND.oids = ["aaa1111abcdef0123456789abcdef0123456789a", full]; // full oids parallel to rows
+    cmdkCtrl.show();
+    cmdkCtrl.filter(full);
+    expect(cmdkCtrl.results.length).toBe(1);
+    expect((cmdkCtrl.results[0] as any).subject).toBe("Add rate limiting");
+  });
+
   it("matches a ref by name", () => {
     setBackendGraph([{ sha: "aaa1111", subject: "Add feature", an: { n: "Dev" }, refs: [{ n: "main", t: "head" }] }]);
     cmdkCtrl.show();

--- a/src/islands/cmdk/cmdk.svelte.ts
+++ b/src/islands/cmdk/cmdk.svelte.ts
@@ -384,7 +384,12 @@ class CmdkState {
         sha = bridge.hhex(r);
         author = bridge.AUTHORS[(Math.imul(r, 2654435761) >>> 5) % bridge.AUTHORS.length].n;
       }
-      out.push({ type: "commit", row: r, subject, sha, author, hay: (subject + " " + sha + " " + author).toLowerCase() });
+      // Haystack carries the FULL 40-char oid (BACKEND.oids[r]), not just the
+      // short display sha, so pasting a full hash into ⌘K matches (#43). The
+      // short sha is the oid's 7-char prefix, so a short-hash search still
+      // matches via the oid. `sha` (short) stays the item's display field.
+      const full = BACKEND && BACKEND.oids && BACKEND.oids[r] ? BACKEND.oids[r] : sha;
+      out.push({ type: "commit", row: r, subject, sha, author, hay: (subject + " " + full + " " + author).toLowerCase() });
     }
     return out;
   }

--- a/src/islands/detail/detail.svelte.test.ts
+++ b/src/islands/detail/detail.svelte.test.ts
@@ -324,6 +324,20 @@ describe("copySha", () => {
     expect(detailCtrl.copied).toBe(false);
     vi.useRealTimers();
   });
+
+  it("copies the FULL oid, not the short display sha (#43)", () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    const full = "a8080adf0123456789abcdef0123456789abcdef"; // 40-char oid
+    setBackendGraph([{ sha: "a8080ad", subject: "Extract swimlane module", an: { n: "Mao", e: "m@nyan.cat", t: 100 }, cm: { n: "Mao", e: "m@nyan.cat", t: 100 }, refs: [] }]);
+    (bridge as any).BACKEND.oids = [full]; // parallel to rows; carries the full hash
+    vi.mocked(commands.commitDetail).mockResolvedValueOnce(
+      ok({ sha: full, shortSha: "a8080ad", subject: "Extract swimlane module", body: "", message: "Extract swimlane module", additions: 0, deletions: 0, filesChanged: 0, truncated: false, fileTree: [] }) as any,
+    );
+    detailCtrl.select(0);
+    detailCtrl.copySha();
+    expect(writeText).toHaveBeenCalledWith(full);
+  });
 });
 
 describe("coverage", () => {

--- a/src/islands/detail/detail.svelte.ts
+++ b/src/islands/detail/detail.svelte.ts
@@ -528,7 +528,11 @@ class DetailState {
 
   copySha() {
     if (!this.commit) return;
-    copyToClipboard(this.commit.sha);
+    // Copy the FULL 40-char oid (BACKEND.oids[row]), not the short sha shown in
+    // the header (#43) — copying a hash is almost always to paste into a git
+    // command. Falls back to the short sha in design mode (no BACKEND).
+    const backend: any = bridge.BACKEND;
+    copyToClipboard((backend && backend.oids && backend.oids[this.commit.row]) || this.commit.sha);
     this.copied = true;
     setTimeout(() => {
       this.copied = false;

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -1324,7 +1324,10 @@ cv.addEventListener("contextmenu",(e)=>{
     const rem=pool.find(r=>r&&r.kind==="remote");
     if(rem){ sidebarCtrl.openCheckoutConfirm(rem.label, true, e.clientX, e.clientY); return; }
   }
-  const sha=(BACKEND&&BACKEND.rows[row])?BACKEND.rows[row].sha:hhex(row);
+  // Full oid (BACKEND.oids[row]), not the short display sha, so the menu's
+  // "Copy full SHA" really copies the full hash and git ops get an unambiguous
+  // ref (#43). openAt derives shortSha from it via slice(0,7).
+  const sha=(BACKEND&&BACKEND.oids&&BACKEND.oids[row])?BACKEND.oids[row]:((BACKEND&&BACKEND.rows[row])?BACKEND.rows[row].sha:hhex(row));
   commitMenuCtrl.openAt(CUR_REPO, sha, msgOf(row), !!(G&&G.isMerge&&G.isMerge[row]), e.clientX, e.clientY);
 });
 cv.addEventListener("keydown",(e)=>{


### PR DESCRIPTION
Fixes #43.

Both symptoms in the issue trace to the same root: the graph rows carry only the **short 7-char sha** (`CommitMeta.sha`), while the **full 40-char oid** lives in the parallel `BACKEND.oids[]` array — and three consumers only ever used the short one.

### 1. Search now matches the full hash
⌘K built its search haystack from the short sha, so pasting a full 40-char hash never matched. It now indexes the **full oid** instead. The short sha is the oid's 7-char prefix, so a short-hash search still matches (no behavior lost, no extra field per row).

### 2. Copying gives the full hash
- **Commit detail panel** (click the hash in the header): copied the short sha shown there. Now copies the **full oid**, and the tooltip says "Click to copy the full hash". The header still *displays* the short sha (readable), which is the standard "show short, copy full" pattern.
- **Commit context menu → "Copy full SHA"**: also copied the short sha, because `openAt()` was handed `BACKEND.rows[row].sha`. Now passed the full oid (`shortSha` is still derived from it via `slice(0,7)`), so "Copy full SHA" / "Copy short SHA" both do the right thing. Git operations off the menu (export patch, reset, cherry-pick) also get an unambiguous full ref.

### Notes
- All `BACKEND.oids` reads are guarded — production always populates it, but a partial `BACKEND` now degrades to the short sha instead of throwing.
- **Tests:** added a full-hash ⌘K match test and a detail `copySha`-copies-full-oid test. svelte-check clean, 1407 vitest pass, `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)