### PR TITLE
feat: focus the existing window for an already-open repo (#39)

### DIFF
--- a/src-tauri/src/instance_focus.rs
+++ b/src-tauri/src/instance_focus.rs
@@ -67,12 +67,18 @@ fn read_entries(path: &PathBuf) -> Vec<Entry> {
 
 fn write_entries(path: &PathBuf, entries: &[Entry]) {
     let Ok(json) = serde_json::to_string(entries) else { return };
-    // Write to a temp file then rename, so a concurrent reader never sees a
-    // half-written registry.
-    let tmp = path.with_extension("json.tmp");
+    // Temp-then-rename so a concurrent READER never sees a half-written file. The
+    // temp name is per-process (pid), so concurrent WRITERS don't clobber a
+    // shared temp. The final rename is still last-writer-wins: two launches
+    // racing can lose one update, but that's rare, benign, and self-heals — the
+    // repo is registered twice (create_initial_window and the frontend's
+    // set_open_repo), and re-registered on the next open — the same tradeoff
+    // repo_registry.rs documents for its own registry.
+    let tmp = path.with_extension(format!("json.tmp.{}", std::process::id()));
     if std::fs::write(&tmp, json).is_ok() {
         let _ = std::fs::rename(&tmp, path);
     }
+    let _ = std::fs::remove_file(&tmp); // clean up if the rename didn't consume it
 }
 
 /// Re-key `port`'s window to `path`: drop this window's previous entry (so an
@@ -114,14 +120,29 @@ pub fn focus_if_open(app: &AppHandle<Wry>, path: &str) -> bool {
 fn focus_if_open_at(reg: &PathBuf, path: &str) -> bool {
     let key = canonical_key(path);
     let mut entries = read_entries(reg);
-    if let Some(pos) = entries.iter().position(|e| e.path == key) {
-        if ping_focus(entries[pos].port) {
-            return true;
+    // A repo can have MORE than one entry (each "Open in New Window" adds its own
+    // port), so try every window registered for this repo and focus the first
+    // reachable one — pruning the dead entries we pass on the way. Only give up
+    // (open fresh) if none are live.
+    let mut focused = false;
+    let mut dead: Vec<usize> = Vec::new();
+    for (i, e) in entries.iter().enumerate() {
+        if e.path != key {
+            continue;
         }
-        entries.remove(pos); // stale window — drop it and open a fresh one
+        if ping_focus(e.port) {
+            focused = true;
+            break;
+        }
+        dead.push(i); // unreachable window for this repo — mark for pruning
+    }
+    if !dead.is_empty() {
+        for &i in dead.iter().rev() {
+            entries.remove(i);
+        }
         write_entries(reg, &entries);
     }
-    false
+    focused
 }
 
 /// Bind this process's focus listener and remember its port. On each incoming
@@ -165,14 +186,21 @@ pub fn start_listener(app: &AppHandle<Wry>) {
 /// (or switches to) a repo, so a later `gitcat <same repo>` finds this window.
 /// Re-keys this window (drops its previous repo entry) so an in-place switch
 /// doesn't leave a stale mapping.
+/// Record that this window now shows `path`, keyed by this process's focus port.
+/// Called at launch (create_initial_window, to close the gap before the frontend
+/// finishes loading) AND by the frontend's `set_open_repo` on every open/switch.
+pub fn register(app: &AppHandle<Wry>, path: &str) {
+    let Some(port) = FOCUS_PORT.get().copied() else { return };
+    let Some(reg) = registry_path(app) else { return };
+    let mut entries = read_entries(&reg);
+    upsert(&mut entries, canonical_key(path), port);
+    write_entries(&reg, &entries);
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn set_open_repo(app: AppHandle<Wry>, path: String) {
-    let Some(port) = FOCUS_PORT.get().copied() else { return };
-    let Some(reg) = registry_path(&app) else { return };
-    let mut entries = read_entries(&reg);
-    upsert(&mut entries, canonical_key(&path), port);
-    write_entries(&reg, &entries);
+    register(&app, &path);
 }
 
 /// JS: `commands.clearOpenRepo()` — called when a repo is closed in-app (the
@@ -251,6 +279,41 @@ mod tests {
         write_entries(&reg, &[Entry { path: canonical_key(&dir_s), port: 1 }]);
         assert!(!focus_if_open_at(&reg, &dir_s), "a dead window must NOT dedup");
         assert!(read_entries(&reg).is_empty(), "the stale entry is pruned");
+        let _ = std::fs::remove_file(&reg);
+    }
+
+    #[test]
+    fn focus_if_open_falls_through_a_dead_duplicate_to_a_live_window() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let dir = std::env::temp_dir();
+        let dir_s = dir.to_str().unwrap().to_string();
+        let key = canonical_key(&dir_s);
+        let reg = std::env::temp_dir().join(format!("gitcat-focus-dup-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&reg);
+
+        // A second, LIVE window for the same repo (Open-in-New-Window leaves two).
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let live_port = listener.local_addr().unwrap().port();
+        let pinged = Arc::new(AtomicBool::new(false));
+        let flag = pinged.clone();
+        let accept = std::thread::spawn(move || {
+            if let Ok((mut s, _)) = listener.accept() {
+                let mut b = [0u8; 16];
+                let _ = s.read(&mut b);
+                flag.store(true, Ordering::SeqCst);
+            }
+        });
+
+        // First entry for the repo is dead (port 1), the second is the live one.
+        write_entries(&reg, &[Entry { path: key.clone(), port: 1 }, Entry { path: key.clone(), port: live_port }]);
+        assert!(focus_if_open_at(&reg, &dir_s), "must fall through the dead duplicate and focus the live window");
+        accept.join().ok();
+        assert!(pinged.load(Ordering::SeqCst), "the live window got the focus ping");
+        let after = read_entries(&reg);
+        assert_eq!(after.len(), 1, "the dead duplicate is pruned, the live one kept");
+        assert_eq!(after[0].port, live_port);
         let _ = std::fs::remove_file(&reg);
     }
 

--- a/src-tauri/src/instance_focus.rs
+++ b/src-tauri/src/instance_focus.rs
@@ -1,0 +1,271 @@
+//! Cross-process "focus the existing window for this repo" (#39).
+//!
+//! GitCat runs a genuinely separate OS process per window (see `windows.rs`), so
+//! launching `gitcat <path>` for a repo that's already open would otherwise
+//! duplicate the window. To avoid that without giving up the separate-process
+//! model, each window binds a loopback TCP listener and records
+//! `<canonical repo path> -> port` in a small on-disk registry. A launch for an
+//! already-open repo connects to that port to raise the existing window, then
+//! exits instead of opening a second one.
+//!
+//! Port reachability doubles as the liveness check: a crashed instance's stale
+//! entry simply fails to connect and is pruned, so there's no PID bookkeeping.
+//! The registry is keyed by the CANONICAL repo path (`.`, symlinks, and Windows
+//! verbatim/UNC forms of the same repo collapse together), and it tracks the
+//! window's CURRENT repo — the frontend calls `set_open_repo` on every open (so
+//! an in-place repo switch re-keys) and `clear_open_repo` when a repo is closed.
+//!
+//! The explicit "Open in New Window" dashboard action passes a `--new-window`
+//! argv marker (see `windows::spawn_new_window`) so it bypasses the dedup and
+//! always gets its own window, as intended.
+
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, Wry};
+
+const FILE_NAME: &str = "open-windows.json";
+const FOCUS_MSG: &[u8] = b"focus\n";
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
+
+/// This process's focus-listener port, set once by [`start_listener`]. Used by
+/// the `set_open_repo`/`clear_open_repo` commands to key this window's entry.
+static FOCUS_PORT: OnceLock<u16> = OnceLock::new();
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Entry {
+    path: String, // canonical repo path (the dedup key)
+    port: u16,    // the owning window's focus-listener port
+}
+
+fn registry_path(app: &AppHandle<Wry>) -> Option<PathBuf> {
+    let dir = app.path().app_config_dir().ok()?;
+    let _ = std::fs::create_dir_all(&dir);
+    Some(dir.join(FILE_NAME))
+}
+
+/// Canonical key for a repo path so different spellings of the same repo dedup
+/// together. Best-effort — falls back to the input when it can't be resolved.
+fn canonical_key(path: &str) -> String {
+    let canon = std::fs::canonicalize(path)
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| path.to_string());
+    crate::windows::strip_windows_verbatim_prefix(canon)
+}
+
+fn read_entries(path: &PathBuf) -> Vec<Entry> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<Vec<Entry>>(&s).ok())
+        .unwrap_or_default()
+}
+
+fn write_entries(path: &PathBuf, entries: &[Entry]) {
+    let Ok(json) = serde_json::to_string(entries) else { return };
+    // Write to a temp file then rename, so a concurrent reader never sees a
+    // half-written registry.
+    let tmp = path.with_extension("json.tmp");
+    if std::fs::write(&tmp, json).is_ok() {
+        let _ = std::fs::rename(&tmp, path);
+    }
+}
+
+/// Re-key `port`'s window to `path`: drop this window's previous entry (so an
+/// in-place repo switch doesn't leave a stale mapping) then record the new one.
+fn upsert(entries: &mut Vec<Entry>, path: String, port: u16) {
+    entries.retain(|e| e.port != port);
+    entries.push(Entry { path, port });
+}
+
+/// Drop `port`'s window from the registry (repo closed, or the window is going
+/// away).
+fn remove_port(entries: &mut Vec<Entry>, port: u16) {
+    entries.retain(|e| e.port != port);
+}
+
+/// Connect to a window's focus port and ask it to raise itself. `true` if the
+/// window was reachable (and thus is really open).
+fn ping_focus(port: u16) -> bool {
+    let addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
+    match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+        Ok(mut s) => s.write_all(FOCUS_MSG).is_ok(),
+        Err(_) => false,
+    }
+}
+
+/// If `path` is already open in another live GitCat window, raise it and return
+/// `true` — the caller should then exit WITHOUT opening a window. A stale
+/// (unreachable) entry for this path is pruned. Returns `false` (open normally)
+/// on any error resolving the registry.
+pub fn focus_if_open(app: &AppHandle<Wry>, path: &str) -> bool {
+    match registry_path(app) {
+        Some(reg) => focus_if_open_at(&reg, path),
+        None => false,
+    }
+}
+
+/// The registry-file half of [`focus_if_open`], split out so it can be tested
+/// against a real listener without a running Tauri app.
+fn focus_if_open_at(reg: &PathBuf, path: &str) -> bool {
+    let key = canonical_key(path);
+    let mut entries = read_entries(reg);
+    if let Some(pos) = entries.iter().position(|e| e.path == key) {
+        if ping_focus(entries[pos].port) {
+            return true;
+        }
+        entries.remove(pos); // stale window — drop it and open a fresh one
+        write_entries(reg, &entries);
+    }
+    false
+}
+
+/// Bind this process's focus listener and remember its port. On each incoming
+/// connection, raise the "main" window on the main thread. Call once, right
+/// after the window is built. Best-effort: a bind failure just means this window
+/// can't be focus-routed to (a later `gitcat <same repo>` would open a new one).
+pub fn start_listener(app: &AppHandle<Wry>) {
+    let listener = match TcpListener::bind((Ipv4Addr::LOCALHOST, 0)) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("gitcat: focus listener bind failed: {e}");
+            return;
+        }
+    };
+    let port = match listener.local_addr() {
+        Ok(a) => a.port(),
+        Err(_) => return,
+    };
+    let _ = FOCUS_PORT.set(port);
+    let app = app.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut s) = stream else { continue };
+            let mut buf = [0u8; 16];
+            let _ = s.read(&mut buf); // we only need the wakeup, not the content
+            let app = app.clone();
+            // Window ops must run on the main thread (see event_util's own note
+            // on background-thread AppHandle calls).
+            let _ = app.clone().run_on_main_thread(move || {
+                if let Some(w) = app.get_webview_window("main") {
+                    let _ = w.unminimize();
+                    let _ = w.show();
+                    let _ = w.set_focus();
+                }
+            });
+        }
+    });
+}
+
+/// JS: `commands.setOpenRepo(path)` — called by the frontend whenever it opens
+/// (or switches to) a repo, so a later `gitcat <same repo>` finds this window.
+/// Re-keys this window (drops its previous repo entry) so an in-place switch
+/// doesn't leave a stale mapping.
+#[tauri::command]
+#[specta::specta]
+pub fn set_open_repo(app: AppHandle<Wry>, path: String) {
+    let Some(port) = FOCUS_PORT.get().copied() else { return };
+    let Some(reg) = registry_path(&app) else { return };
+    let mut entries = read_entries(&reg);
+    upsert(&mut entries, canonical_key(&path), port);
+    write_entries(&reg, &entries);
+}
+
+/// JS: `commands.clearOpenRepo()` — called when a repo is closed in-app (the
+/// window stays open with no repo). Removes this window's registry entry so it's
+/// no longer a focus target. (An OS-close exits the process; its now-unreachable
+/// entry is pruned lazily by the next launch's [`focus_if_open`].)
+#[tauri::command]
+#[specta::specta]
+pub fn clear_open_repo(app: AppHandle<Wry>) {
+    let Some(port) = FOCUS_PORT.get().copied() else { return };
+    let Some(reg) = registry_path(&app) else { return };
+    let mut entries = read_entries(&reg);
+    remove_port(&mut entries, port);
+    write_entries(&reg, &entries);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upsert_re_keys_a_windows_repo_and_leaves_others_alone() {
+        let mut e: Vec<Entry> = Vec::new();
+        upsert(&mut e, "/repo/a".into(), 100);
+        upsert(&mut e, "/repo/b".into(), 200);
+        assert_eq!(e.len(), 2);
+        // Window on port 100 switches repo in place: its /a entry is replaced by
+        // /c, and port 200's /b entry is untouched.
+        upsert(&mut e, "/repo/c".into(), 100);
+        assert_eq!(e.len(), 2);
+        assert!(!e.iter().any(|x| x.path == "/repo/a"), "stale key must be dropped");
+        assert!(e.iter().any(|x| x.path == "/repo/c" && x.port == 100));
+        assert!(e.iter().any(|x| x.path == "/repo/b" && x.port == 200));
+    }
+
+    #[test]
+    fn remove_port_drops_only_that_window() {
+        let mut e: Vec<Entry> = Vec::new();
+        upsert(&mut e, "/repo/a".into(), 100);
+        upsert(&mut e, "/repo/b".into(), 200);
+        remove_port(&mut e, 100);
+        assert_eq!(e.len(), 1);
+        assert_eq!(e[0].path, "/repo/b");
+    }
+
+    #[test]
+    fn focus_if_open_pings_a_live_window_and_prunes_a_dead_one() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        // A real repo path so canonical_key resolves identically on both sides.
+        let dir = std::env::temp_dir();
+        let dir_s = dir.to_str().unwrap().to_string();
+        let reg = std::env::temp_dir().join(format!("gitcat-focus-live-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&reg);
+
+        // Stand in for an open window: a listener that flips a flag when pinged.
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let pinged = Arc::new(AtomicBool::new(false));
+        let flag = pinged.clone();
+        let accept = std::thread::spawn(move || {
+            if let Ok((mut s, _)) = listener.accept() {
+                let mut b = [0u8; 16];
+                let _ = s.read(&mut b);
+                flag.store(true, Ordering::SeqCst);
+            }
+        });
+
+        write_entries(&reg, &[Entry { path: canonical_key(&dir_s), port }]);
+        assert!(focus_if_open_at(&reg, &dir_s), "a live window must be focused (open dedup'd)");
+        accept.join().ok();
+        assert!(pinged.load(Ordering::SeqCst), "the focus ping reached the listener");
+
+        // A stale entry (nothing listening on port 1) prunes and opens fresh.
+        write_entries(&reg, &[Entry { path: canonical_key(&dir_s), port: 1 }]);
+        assert!(!focus_if_open_at(&reg, &dir_s), "a dead window must NOT dedup");
+        assert!(read_entries(&reg).is_empty(), "the stale entry is pruned");
+        let _ = std::fs::remove_file(&reg);
+    }
+
+    #[test]
+    fn registry_survives_a_write_read_round_trip() {
+        let tmp = std::env::temp_dir().join(format!("gitcat-focus-{}.json", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        assert!(read_entries(&tmp).is_empty(), "missing file reads as empty");
+        let mut e: Vec<Entry> = Vec::new();
+        upsert(&mut e, "/repo/a".into(), 4242);
+        write_entries(&tmp, &e);
+        let back = read_entries(&tmp);
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].port, 4242);
+        assert_eq!(back[0].path, "/repo/a");
+        let _ = std::fs::remove_file(&tmp);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub mod tool_settings; // backlog #12: external diff/merge tool settings + deleg
 pub mod trust; // auto-trust WSL/UNC-path repos libgit2 refuses as "dubious ownership"
 pub mod watch; // live refresh: watch the open repo's git-dir for externally-made changes
 pub mod windows; // multi-window: spawn a fresh, fully independent GitCat process, optionally pointed directly at a repo
+pub mod instance_focus; // #39: focus the existing window for an already-open repo instead of duplicating it (per-repo loopback registry)
 pub mod cli_shim; // "Install 'gitcat' command in PATH": writes a VS Code `code`-style launcher (macOS /usr/local/bin, Linux ~/.local/bin, Windows WindowsApps)
 pub mod i18n_err; // PER-82: app-authored errors as `i18n:<key>` strings the frontend's be() translates (raw git stderr stays passthrough)
 pub mod updater; // channel-aware "check for updates" (stable vs nightly endpoint + downgrade-allowing comparator)
@@ -342,6 +343,10 @@ fn specta_builder() -> Builder<tauri::Wry> {
         // generic "New Window" menu item is handled entirely in Rust, see
         // menu.rs's own handle_event — no command round trip for that path).
         windows::open_repo_in_new_window,
+        // #39: the frontend registers/clears this window's current repo so a
+        // later `gitcat <same repo>` focuses it (see instance_focus.rs).
+        instance_focus::set_open_repo,
+        instance_focus::clear_open_repo,
         // Native-menu i18n (PER-80): the frontend pushes the current locale's
         // menu labels here so Rust rebuilds + swaps the OS menu (menu.rs).
         menu::set_app_menu,

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -95,7 +95,7 @@ fn window_url(arg: &InitialArg) -> WebviewUrl {
 /// `\\?\C:\…` back to `C:\…`. A path without the prefix (every non-Windows
 /// path, and any already-plain input) is returned untouched, so this is safe to
 /// call unconditionally. Pure string work, unit-tested on every platform.
-fn strip_windows_verbatim_prefix(p: String) -> String {
+pub(crate) fn strip_windows_verbatim_prefix(p: String) -> String {
     if let Some(rest) = p.strip_prefix(r"\\?\UNC\") {
         format!(r"\\{rest}")
     } else if let Some(rest) = p.strip_prefix(r"\\?\") {
@@ -155,6 +155,15 @@ fn initial_arg() -> InitialArg {
 /// process was launched with.
 pub fn create_initial_window(app: &AppHandle<Wry>) -> tauri::Result<()> {
     let arg = initial_arg();
+    // #39: if this repo is already open in another window — and this launch
+    // isn't the explicit "Open in New Window" action (which passes `--new-window`,
+    // see spawn_new_window) — raise that window and exit instead of duplicating
+    // it. `gitcat <same repo>` run twice now focuses the first window.
+    if let InitialArg::Repo(p) = &arg {
+        if !std::env::args().any(|a| a == "--new-window") && crate::instance_focus::focus_if_open(app, p) {
+            std::process::exit(0);
+        }
+    }
     // Best-effort terminal hint for `gitcat <not-a-repo>`, visible when launched
     // from a shell (a GUI double-click has no attached terminal — there the
     // in-app hint via ?repoError=, surfaced by legacy/main.ts's boot dispatch,
@@ -168,6 +177,10 @@ pub fn create_initial_window(app: &AppHandle<Wry>) -> tauri::Result<()> {
         .min_inner_size(WINDOW_MIN_W, WINDOW_MIN_H)
         .center()
         .build()?;
+    // #39: start this window's focus listener so a later `gitcat <same repo>`
+    // can raise it. The repo itself is registered by the frontend via
+    // set_open_repo once it opens (which also covers in-place repo switches).
+    crate::instance_focus::start_listener(app);
     Ok(())
 }
 
@@ -212,7 +225,10 @@ pub fn spawn_new_window(repo_path: Option<&str>) {
         let mut cmd = Command::new("open");
         cmd.arg("-n").arg("-a").arg(&bundle);
         if let Some(p) = repo_path {
-            cmd.arg("--args").arg(p);
+            // `--new-window` after the repo reaches the new instance's argv and
+            // tells it to skip the #39 already-open dedup — this is the explicit
+            // "Open in New Window" action, which SHOULD get its own window.
+            cmd.arg("--args").arg(p).arg("--new-window");
         }
         match cmd.spawn() {
             Ok(_) => return,
@@ -225,7 +241,7 @@ pub fn spawn_new_window(repo_path: Option<&str>) {
     // foreground on its own, so no LaunchServices dance is needed.
     let mut cmd = Command::new(&exe);
     if let Some(p) = repo_path {
-        cmd.arg(p);
+        cmd.arg(p).arg("--new-window"); // explicit new window: skip the #39 dedup
     }
     cmd.no_console_window();
     if let Err(e) = cmd.spawn() {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -171,21 +171,23 @@ pub fn create_initial_window(app: &AppHandle<Wry>) -> tauri::Result<()> {
     if let InitialArg::NotRepo(p) = &arg {
         eprintln!("gitcat: {p} is not a git repository");
     }
+    // #39: bind this window's focus listener and register the launch repo BEFORE
+    // building the (comparatively slow) webview — otherwise a re-launch during
+    // window creation / the initial graph load finds no entry and duplicates the
+    // window, which is the impatient `gitcat . ; gitcat .` case this targets. The
+    // focus handler resolves the "main" window lazily when a ping actually
+    // arrives (seconds later, once it's built), so listening first is safe.
+    // set_open_repo keeps the entry current across in-place repo switches.
+    crate::instance_focus::start_listener(app);
+    if let InitialArg::Repo(p) = &arg {
+        crate::instance_focus::register(app, p);
+    }
     WebviewWindowBuilder::new(app, "main", window_url(&arg))
         .title(WINDOW_TITLE)
         .inner_size(WINDOW_W, WINDOW_H)
         .min_inner_size(WINDOW_MIN_W, WINDOW_MIN_H)
         .center()
         .build()?;
-    // #39: start this window's focus listener, then register the launch repo
-    // RIGHT AWAY (not just later via the frontend's set_open_repo) — otherwise an
-    // impatient re-launch during the initial graph load finds no entry and
-    // duplicates the window. set_open_repo keeps it current across in-place
-    // switches from there.
-    crate::instance_focus::start_listener(app);
-    if let InitialArg::Repo(p) = &arg {
-        crate::instance_focus::register(app, p);
-    }
     Ok(())
 }
 

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -177,10 +177,15 @@ pub fn create_initial_window(app: &AppHandle<Wry>) -> tauri::Result<()> {
         .min_inner_size(WINDOW_MIN_W, WINDOW_MIN_H)
         .center()
         .build()?;
-    // #39: start this window's focus listener so a later `gitcat <same repo>`
-    // can raise it. The repo itself is registered by the frontend via
-    // set_open_repo once it opens (which also covers in-place repo switches).
+    // #39: start this window's focus listener, then register the launch repo
+    // RIGHT AWAY (not just later via the frontend's set_open_repo) — otherwise an
+    // impatient re-launch during the initial graph load finds no entry and
+    // duplicates the window. set_open_repo keeps it current across in-place
+    // switches from there.
     crate::instance_focus::start_listener(app);
+    if let InitialArg::Repo(p) = &arg {
+        crate::instance_focus::register(app, p);
+    }
     Ok(())
 }
 

--- a/src-tauri/tests/tool_settings.rs
+++ b/src-tauri/tests/tool_settings.rs
@@ -235,10 +235,18 @@ fn singleton_still_wins_over_gitconfig_and_named_falls_back_to_singleton_when_de
 /// into two fixed marker files under `out_dir`, so the test can assert their
 /// exact content without ever launching a real GUI diff tool.
 fn recording_diff_cmd(out_dir: &Path) -> String {
+    // Copy to a temp then `mv` (an atomic rename within the same dir) so each
+    // .out file only ever appears with its FULL content. `wait_for()` polls for
+    // existence, so a plain non-atomic `cp` left a window where the file existed
+    // but was still empty — a loaded CI runner could read it then, giving a
+    // flaky `""` (see tool_settings.rs:210). The temp lives in the same out_dir
+    // so the rename stays on one filesystem.
+    let local = out_dir.join("local.out");
+    let remote = out_dir.join("remote.out");
     format!(
-        "cp \"$LOCAL\" '{}' && cp \"$REMOTE\" '{}'",
-        out_dir.join("local.out").display(),
-        out_dir.join("remote.out").display()
+        "cp \"$LOCAL\" '{l}.tmp' && mv '{l}.tmp' '{l}' && cp \"$REMOTE\" '{r}.tmp' && mv '{r}.tmp' '{r}'",
+        l = local.display(),
+        r = remote.display(),
     )
 }
 

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -3223,6 +3223,24 @@ async openRepoInNewWindow(path: string) : Promise<void> {
     await TAURI_INVOKE("open_repo_in_new_window", { path });
 },
 /**
+ * JS: `commands.setOpenRepo(path)` — called by the frontend whenever it opens
+ * (or switches to) a repo, so a later `gitcat <same repo>` finds this window.
+ * Re-keys this window (drops its previous repo entry) so an in-place switch
+ * doesn't leave a stale mapping.
+ */
+async setOpenRepo(path: string) : Promise<void> {
+    await TAURI_INVOKE("set_open_repo", { path });
+},
+/**
+ * JS: `commands.clearOpenRepo()` — called when a repo is closed in-app (the
+ * window stays open with no repo). Removes this window's registry entry so it's
+ * no longer a focus target. (An OS-close exits the process; its now-unreachable
+ * entry is pruned lazily by the next launch's [`focus_if_open`].)
+ */
+async clearOpenRepo() : Promise<void> {
+    await TAURI_INVOKE("clear_open_repo");
+},
+/**
  * Rebuild the native menu with frontend-supplied labels and swap it in — the
  * runtime half of i18n for the OS menu (PER-80). Called by `syncNativeMenu` in
  * legacy/main.ts on boot (when the locale isn't the English default) and on

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -2918,6 +2918,10 @@ async function openRepo(path){
       await startGraphStream(path);
     }
     CUR_REPO = path;
+    // #39: tell the backend this window now shows `path`, so a later
+    // `gitcat <same repo>` focuses this window instead of opening a duplicate.
+    // Fire-and-forget; re-keys on an in-place repo switch (see instance_focus.rs).
+    if(IN_TAURI) void commands.setOpenRepo(path);
     // Auto-prune old Safety-Manager snapshots per the user's retention policy,
     // once per repo-open. Fire-and-forget (never awaited — must not delay the
     // open); a no-op unless the policy is set to something other than "off".
@@ -3337,6 +3341,9 @@ function bootEmpty(){
 // reset the submodule-nav strip that renders the breadcrumb).
 async function closeRepo(){
   if(!IN_TAURI||!CUR_REPO) return;
+  // #39: this window no longer shows a repo — drop its focus-registry entry so
+  // `gitcat <that repo>` opens fresh rather than focusing an empty window.
+  void commands.clearOpenRepo();
   await bisectCtrl.cancelIfRunning();
   bootEmpty();
   NAV_STACK.length=0;


### PR DESCRIPTION
Fixes #39.

Running `gitcat <path>` (or re-running it) for a repo that's already open duplicated the window, because every GitCat window is a deliberately separate OS process with no cross-process coordination. This adds **per-repo coordination that keeps the separate-process model** (rather than reverting to single-instance / in-process multi-window, which would reintroduce the graph-canvas hover bug that design avoids).

### How it works — `src-tauri/src/instance_focus.rs`
- Each window binds a **loopback TCP listener** and records `<canonical repo path> -> port` in a tiny on-disk registry (`open-windows.json` in the app-config dir). The frontend calls `set_open_repo` on every `openRepo` (so an **in-place repo switch re-keys** the entry) and `clear_open_repo` when a repo is closed.
- `create_initial_window` checks the registry **before** building the window: if the launch repo is already open in a live window, it connects to that window's port to **raise it** (`unminimize` + `show` + `set_focus`) and **exits** without opening a duplicate.
- **Port reachability is the liveness check** — a crashed instance's stale entry simply fails to connect and is pruned, so there's no PID bookkeeping or leaked state.
- Keys are canonicalized (reusing `windows::strip_windows_verbatim_prefix`), so `.`, symlinks, and Windows verbatim/UNC spellings of the same repo dedup together.

### "Open in New Window" still works
The dashboard's explicit action passes a `--new-window` argv marker (via `spawn_new_window`) so it **bypasses the dedup** and always gets its own window, as the issue asked.

### Tests / verification
- New unit tests: registry `upsert` re-key, `remove_port`, write/read round-trip.
- A real-listener integration test: the cross-process **focus ping reaches a live window** (dedup returns true) and a **dead entry is pruned** (returns false, opens fresh).
- `cargo test --lib` 263 pass, svelte-check clean, 1407 vitest, `pnpm build` clean. Windows/Linux compile on CI.

### Remaining
The registry + cross-process ping are covered by tests, but the actual **GUI window-focus and the launch-time `process::exit(0)`** can only be checked on a real build. Worth a quick per-platform smoke test: open repo X, run `gitcat .` in X again -> the existing window should come to front (no second window); a *different* repo should still open a new window; and dashboard "Open in New Window" should still duplicate on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)