### PR TITLE
fix(sidebar): a later jump supersedes an armed warning, success included

### DIFF
--- a/src/islands/sidebar/sidebar.svelte.test.ts
+++ b/src/islands/sidebar/sidebar.svelte.test.ts
@@ -2821,6 +2821,27 @@ describe("jumpToRef (click a sidebar ref -> select its tip commit)", () => {
     expect(bridge.tama.warn).not.toHaveBeenCalled();
   });
 
+  it("a later SUCCESSFUL jump supersedes an armed warning — no scolding about the ref you left", () => {
+    vi.mocked(bridge.goToOid).mockReturnValue(false);
+    sidebarCtrl.jumpToRef("tag", "v0.9.0", "a".repeat(40)); // not loaded -> warning armed
+    vi.advanceTimersByTime(100); // still inside the hold
+    vi.mocked(bridge.goToOid).mockReturnValue(true);
+    sidebarCtrl.jumpToRef("tag", "v1.0.0", "b".repeat(40)); // lands fine
+    flushWarning();
+    expect(bridge.tama.warn).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("a later FAILING jump replaces the armed warning rather than adding to it", () => {
+    vi.mocked(bridge.goToOid).mockReturnValue(false);
+    sidebarCtrl.jumpToRef("tag", "v0.9.0", "a".repeat(40));
+    vi.advanceTimersByTime(100);
+    sidebarCtrl.jumpToRef("tag", "v1.0.0", "b".repeat(40));
+    flushWarning();
+    expect(bridge.tama.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(bridge.tama.warn).mock.calls[0][0]).toContain("v1.0.0");
+  });
+
   it("a SUCCESSFUL jump is never delayed — no timer on the common case", () => {
     vi.mocked(bridge.goToOid).mockReturnValue(true);
     sidebarCtrl.jumpToRef("local", "main", "a".repeat(40));

--- a/src/islands/sidebar/sidebar.svelte.ts
+++ b/src/islands/sidebar/sidebar.svelte.ts
@@ -831,6 +831,12 @@ class SidebarState {
   // to tick, a branch that simply hasn't streamed in yet is already ticked,
   // and a graph that stopped short never had the commit to begin with.
   jumpToRef(section: RefSection, name: string, sha: string): void {
+    // Every outcome of this call supersedes whatever an earlier click armed,
+    // success included — which is why the cancel lives here and not inside
+    // warnJumpFailed. Click a ref that isn't loaded, then click a different one
+    // within the hold and land on it: without this, the first ref's warning
+    // still fires half a second later, naming a ref you have already left.
+    this.cancelJumpWarning();
     if (!sha) {
       this.warnJumpFailed(t("sidebar.jump_no_commit", { name }));
       return;
@@ -891,6 +897,8 @@ class SidebarState {
   // only fixes the FAST half of real double-clicks — see JUMP_WARN_HOLD_MS.
   private jumpWarnTimer: ReturnType<typeof setTimeout> | null = null;
   private warnJumpFailed(msg: string): void {
+    // jumpToRef has already cancelled any pending warning by the time it calls
+    // this; the clear here only covers a caller that hasn't.
     this.cancelJumpWarning();
     this.jumpWarnTimer = setTimeout(() => {
       this.jumpWarnTimer = null;


### PR DESCRIPTION
Picks up the non-blocking note you left when approving #28.

The cancel lived inside `warnJumpFailed`, so the two success paths returned without clearing a warning an earlier click had already armed. Click a ref that isn't loaded, then click a different one inside the hold window and land on it — half a second later Tama scolds you about the first ref while you're looking at the second.

It's the same stale-scolding the hold was added to prevent, just across two refs instead of inside one double-click. Moving the cancel to the top of `jumpToRef` makes every outcome supersede whatever was pending, which is what the hold should have meant all along. `warnJumpFailed` keeps its own clear for any caller that doesn't go through `jumpToRef`.

## Tests

Two, and they're not the same kind — worth separating so the second doesn't look like evidence it isn't:

- **`a later SUCCESSFUL jump supersedes an armed warning`** — the regression. I reverted the one-line change and confirmed it fails without it, then put it back.
- **`a later FAILING jump replaces the armed warning rather than adding to it`** — passes with or without this change, because `warnJumpFailed` already cleared. It's there to pin the behaviour if that inner clear is ever removed as redundant, not to prove the fix.

`svelte-check` 0 errors · vitest 1440/1440 (default parallel pool).

Thanks for writing the repro out in the review — it dropped straight into a spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
