### PR TITLE
Release for v1.2.0 (Aug 20th)

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,7 +17,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gitcat";
-  version = "1.1.0";
+  version = "1.2.0";
 
   inherit src;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitcat",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "GPL-3.0-or-later",
   "type": "module",
   "packageManager": "pnpm@10.34.5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "gitcat"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "base64 0.22.1",
  "console-subscriber",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitcat"
-version = "1.1.0"
+version = "1.2.0"
 description = "A cozy, safety-first desktop Git client."
 authors = ["Jiucheng Zang <git.jiucheng@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GitCat",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "com.jiucheng.gitcat",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump only — the same five files the v1.1.0 cut touched (#33): `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `nix/package.nix`.

`cargo build --locked` accepts the lockfile, so the `gitcat` entry is consistent.

Tag `v1.2.0` follows on the merge commit, which is what triggers `release.yml`'s 6-platform matrix into a draft release.

## In this release

- **Korean (한국어)** — #51, #52. Third full locale.
- **Image & PDF diffs** — #50. Side-by-side before/after with a zoom lightbox and per-side download; PDFs rasterized by PDFium in the Rust core.
- **Bisect fixed on git 2.55+** — #56. `git bisect log` started quoting the term in 2.55, which made `parse_first_bad` return `None` forever: automated runs looped without terminating and manual bisects never reported convergence. Found while cutting this release.
- **Graph & sidebar** — #28, #48, #47.
- **Fixes** — #45, #44, #40, #38.
- **Docs site** — #53, #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)