### PR TITLE
Make the Rust test suite runnable on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,20 +188,24 @@ jobs:
   # otherwise unverified until a tagged release runs the 6-platform matrix. This
   # catches a Windows-only compile break on the PR instead.
   #
-  # Compile-only, on purpose:
+  # Compile-only, on purpose — but the reason changed, so read this before
+  # assuming it still can't run:
   #  - `cargo build` covers the app/library binary.
   #  - `cargo test --lib --no-run` additionally COMPILES the library unit-test
-  #    code on Windows (Windows-clean: the handful of Unix-only cases are
-  #    #[cfg(unix)]-guarded), catching a Windows test-compile break too. `--lib`
-  #    skips the tests/ integration suite (submodule / repo_registry /
-  #    repo_files), which uses unguarded std::os::unix APIs and doesn't compile
-  #    on Windows yet (a separate follow-up).
-  #  - We deliberately do NOT run the tests. The Tauri library's test binary
-  #    transitively links the WebView2/wry native stack and fails to resolve a
-  #    DLL entry point at startup on a stock runner (exit 0xc0000139,
-  #    STATUS_ENTRYPOINT_NOT_FOUND) before any test executes. The cli_shim
-  #    launcher tests are platform-agnostic pure functions already run by the
-  #    Linux `rust` job, so running them here would add nothing regardless.
+  #    code on Windows, catching a Windows test-compile break too.
+  #  - The whole test suite now COMPILES on Windows, and the library test
+  #    binary now STARTS. It used to die at startup with exit 0xc0000139
+  #    (STATUS_ENTRYPOINT_NOT_FOUND) before any test ran, because it imports a
+  #    comctl32 v6 export without the manifest that binds v6; build.rs
+  #    delay-loads comctl32 to fix that, and the two remaining Unix-only cases
+  #    in tests/submodule.rs are #[cfg(unix)]-guarded.
+  #  - We still do NOT run the tests here, and that is now a real choice rather
+  #    than an impossibility. Locally the suite is 613 passed / 88 failed on
+  #    Windows: one library test (a ConPTY round-trip that reads nothing) plus
+  #    an integration cluster concentrated in workdir/merge/rebase/submodule.
+  #    Those are pre-existing Windows gaps that have never been allowed to run
+  #    before, not regressions. Turning the run on is a follow-up that belongs
+  #    with fixing them — flipping it now would just make every PR red.
   # No apt/system-deps step: Windows runners ship the MSVC toolchain and WebView2
   # SDK, and libgit2-sys builds its vendored copy with `cc`, same as on Linux.
   rust-windows:

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,5 +8,88 @@ fn main() {
     // reports "Compiling gitcat". Watch the whole icons/ directory so any
     // icon regeneration always re-embeds correctly.
     println!("cargo:rerun-if-changed=icons");
+    delay_load_comctl32_on_windows();
     tauri_build::build()
+}
+
+/// Let the library's unit-test binary START on Windows.
+///
+/// It could not. `cargo test --lib` exited with STATUS_ENTRYPOINT_NOT_FOUND
+/// (0xC0000139) before the harness ran anything, which took `export_bindings`
+/// — the test that regenerates `src/ipc/bindings.ts` — down with it. CI runs
+/// the Rust suite on Linux, so nothing caught it.
+///
+/// Cause: this binary imports `comctl32!TaskDialogIndirect`, which exists only
+/// in comctl32 **version 6**. `C:\Windows\System32\comctl32.dll` is v5 and does
+/// not export it; v6 lives in a side-by-side assembly the loader binds only for
+/// a process whose manifest declares a `Microsoft.Windows.Common-Controls`
+/// 6.0.0.0 dependency. `tauri_build` embeds that manifest in the APP binary and
+/// nothing embeds it in a test binary.
+///
+/// Scope, since the shape of this is easy to overstate: exactly TWO binaries in
+/// the build carry comctl32 imports — the app and the lib unit-test exe.
+/// `dumpbin /DEPENDENTS` over `target/debug/deps/*.exe` shows none of the
+/// `tests/*.rs` integration binaries reference comctl32 at all, and a
+/// pre-change integration exe still runs. What made the whole command report
+/// `0 passed, 0 failed` was the separate compile error in `tests/submodule.rs`
+/// (now `cfg(unix)`-gated): one non-compiling target makes `cargo test
+/// --no-fail-fast` emit no test results whatsoever.
+///
+/// The import comes from `tauri-runtime-wry`'s own `dialog/windows.rs`, which
+/// is compiled unconditionally on Windows, and from `muda`/`rfd` under the
+/// dialog plugin — so it is not something a feature flag can drop.
+///
+/// ## Why delay-loading rather than embedding the manifest
+///
+/// There is no way to reach only the test binaries. All three alternatives
+/// were measured, so nobody has to repeat them:
+///
+/// - `cargo:rustc-link-arg-tests` does NOT apply to the lib's own unit-test
+///   target — the one that needs it. It covers `tests/*.rs` only. (Measured
+///   with `/VERSION:7.7`: the integration exe is stamped, the lib-test exe is
+///   not.)
+/// - The unscoped `cargo:rustc-link-arg` does reach it, but also reaches the
+///   app, where `/MANIFEST:EMBED` collides with the manifest resource
+///   tauri-build already generated: `CVT1100: duplicate resource.
+///   type:MANIFEST, name:1` then `LNK1123`. `/MANIFESTINPUT` without
+///   `/MANIFEST:EMBED` is `LNK1220`, so the pair cannot be split.
+/// - A side-by-side `<exe>.manifest` is not something a build script can
+///   place: it cannot know the test binary's hashed filename.
+///
+/// The duplicate — not manifest embedding as such — is what blocks that route.
+/// `tauri_build::WindowsAttributes::new_without_app_manifest()` would hand this
+/// file ownership of the app manifest and let an unscoped `/MANIFEST:EMBED`
+/// cover every target, keeping the app statically bound. That is a real option,
+/// deliberately not taken: it makes this build script responsible for a
+/// manifest tauri-build generates and evolves, which is a standing maintenance
+/// cost for a test-only problem.
+///
+/// ## What delay-loading costs
+///
+/// The app still gets v6: its manifest is in force by the time the DLL is
+/// actually loaded (verified by launching the built app and reading
+/// `Process.Modules` — comctl32 resolves from the WinSxS 6.0 assembly). The
+/// tests never call `TaskDialogIndirect`, so the import is never resolved and
+/// the process starts.
+///
+/// The trade is fail-fast for fail-late. If the app's manifest were ever lost
+/// — a tauri-build upgrade, a bundler or re-signing step that rewrites
+/// resources — the old behaviour was a loader error at startup, before any user
+/// data was in play. Now it is an unhandled structured exception
+/// (`0xC06D007F`) at the moment a dialog opens. Worth knowing before blaming
+/// the dialog code.
+fn delay_load_comctl32_on_windows() {
+    // TARGET, not HOST: a Windows cross-build from Linux still needs this, and
+    // a Linux build hosted on Windows must not get MSVC linker flags. Both
+    // shipped Windows targets are `*-pc-windows-msvc` (see release.yml);
+    // `*-pc-windows-gnu` is deliberately excluded, since these are MSVC-only
+    // flags — a GNU-toolchain Windows build is not something this repo ships,
+    // and would need its own answer.
+    if !std::env::var("TARGET").unwrap_or_default().contains("windows-msvc") {
+        return;
+    }
+    println!("cargo:rustc-link-arg=/DELAYLOAD:comctl32.dll");
+    // Provides __delayLoadHelper2, which the delay-load stubs call. Without it
+    // the link fails with LNK2001 on that symbol.
+    println!("cargo:rustc-link-arg=delayimp.lib");
 }

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -45,13 +45,28 @@ impl TempRepo {
         std::fs::create_dir_all(&dir).expect("mkdir temp repo");
         let repo = TempRepo { dir };
         repo.must(&["init", "-q", "-b", "main"]);
+        repo.apply_test_config();
+        repo
+    }
+
+    /// The repo-LOCAL config every throwaway working-tree repo needs, in one
+    /// place because there is more than one way a test builds one: `init`
+    /// above, and `patch.rs`'s `clone_of`, which used to hand-copy a subset of
+    /// this list and drifted out of sync with it.
+    ///
+    /// Everything here is set LOCALLY on purpose. `git()` below neutralizes the
+    /// host's global/system config for its OWN invocations, but the code under
+    /// test shells out to `git` itself with no such environment — so anything
+    /// that must hold for the code under test has to live in the repo, where it
+    /// outranks the host's global config.
+    pub fn apply_test_config(&self) {
         // CRITICAL: without this, a commit hangs forever on a GPG passphrase prompt.
-        repo.must(&["config", "commit.gpgsign", "false"]);
+        self.must(&["config", "commit.gpgsign", "false"]);
         // Separate config key from commit.gpgsign — needed once a test creates
         // an annotated tag (`git tag -a`, e.g. tests/plumbing.rs); without this,
         // a host with tag signing defaulted on would hang the ENTIRE shared
         // test binary (this file is `mod common`'d by every tests/*.rs file).
-        repo.must(&["config", "tag.gpgsign", "false"]);
+        self.must(&["config", "tag.gpgsign", "false"]);
         // CRITICAL: repo-LOCAL identity, independent of any GIT_AUTHOR_*/GIT_COMMITTER_*
         // env vars (see `git()` below) or the machine's global/system git config. Code
         // under test (e.g. git_pick::cherry_pick_continue) shells out to git directly
@@ -63,16 +78,35 @@ impl TempRepo {
         // config sits above that fallback and below explicit env vars in git's identity
         // resolution, so this makes every throwaway repo self-sufficient regardless of
         // the host's global config or GECOS data.
-        repo.must(&["config", "user.name", "GitCat Test"]);
-        repo.must(&["config", "user.email", "test@gitcat.example"]);
+        self.must(&["config", "user.name", "GitCat Test"]);
+        self.must(&["config", "user.email", "test@gitcat.example"]);
+        // Line endings, for the same reason as the identity above: Git for
+        // Windows installs `core.autocrlf=true` by default, which rewrites LF to
+        // CRLF on every checkout. A test writes "base\nline2\n", the code under
+        // test performs an operation that re-checkouts the file, and the
+        // assertion then compares against "base\r\nline2\r\n" — 58 failures on a
+        // Windows host, all of them the test being platform-naive rather than
+        // anything being wrong. Twelve more showed up as `is_clean()` returning
+        // false, the same cause wearing a different hat: git reports a file as
+        // modified when its line endings no longer match what the index expects.
+        //
+        // `core.eol` as well as autocrlf: autocrlf alone still leaves `eol` to
+        // decide the checkout form for paths marked `text` by a .gitattributes
+        // file, and some tests write one.
+        //
+        // This does NOT mean the app is untested against CRLF working trees —
+        // it means these assertions are about git plumbing, not about line
+        // endings, and a real user's autocrlf setting has no business deciding
+        // whether they pass.
+        self.must(&["config", "core.autocrlf", "false"]);
+        self.must(&["config", "core.eol", "lf"]);
         // Disable background auto-gc/maintenance: a test that creates MANY commits
         // rapidly (dashboard's `stays_cheap_…` runs a 300-commit loop) otherwise
         // intermittently trips `git gc --auto` repacking behind the next commit —
         // observed as a flaky CI failure "error: bad tree object HEAD" mid-loop.
         // No test needs gc, so turn it off outright for every throwaway repo.
-        repo.must(&["config", "gc.auto", "0"]);
-        repo.must(&["config", "maintenance.auto", "false"]);
-        repo
+        self.must(&["config", "gc.auto", "0"]);
+        self.must(&["config", "maintenance.auto", "false"]);
     }
 
     /// A bare repo (no working tree) — stands in for a real remote in

--- a/src-tauri/tests/patch.rs
+++ b/src-tauri/tests/patch.rs
@@ -37,10 +37,11 @@ fn clone_of(src: &TempRepo, tag: &str) -> TempRepo {
         .expect("failed to spawn git clone");
     assert!(out.status.success(), "git clone failed: {}", String::from_utf8_lossy(&out.stderr));
     let repo = TempRepo { dir };
-    repo.must(&["config", "commit.gpgsign", "false"]);
-    repo.must(&["config", "tag.gpgsign", "false"]);
-    repo.must(&["config", "user.name", "GitCat Test"]);
-    repo.must(&["config", "user.email", "test@gitcat.example"]);
+    // A clone starts with none of the source repo's local config, so it needs
+    // the same treatment `TempRepo::init` gives. This used to be a hand-copied
+    // subset of that list, which is how it ended up missing the line-ending
+    // settings and failing three tests on Windows.
+    repo.apply_test_config();
     repo
 }
 

--- a/src-tauri/tests/submodule.rs
+++ b/src-tauri/tests/submodule.rs
@@ -1752,6 +1752,11 @@ fn bug2_remove_refuses_when_a_nested_submodule_of_a_submodule_is_dirty() {
     assert!(!status_after.contains("D  sub"), "sub's gitlink must not have been staged for deletion: {status_after:?}");
 }
 
+// Unix-only: the precondition is a read-only DIRECTORY, which is what makes
+// the `.gitmodules` rewrite fail. Windows ignores the read-only attribute for
+// that purpose — there is no equivalent using file attributes, and an ACL deny
+// would be more machinery than this test is worth.
+#[cfg(unix)]
 #[test]
 fn bug3_remove_propagates_a_failed_gitmodules_fallback_instead_of_reporting_ok() {
     // BUG 3: the `.gitmodules` section-removal fallback (for when `git rm -f`
@@ -1804,6 +1809,9 @@ fn bug3_remove_propagates_a_failed_gitmodules_fallback_instead_of_reporting_ok()
     );
 }
 
+// Unix-only: needs a dangling symlink, which on Windows requires either
+// Developer Mode or elevation — not something a test run can assume.
+#[cfg(unix)]
 #[test]
 fn bug4_force_deinit_backs_up_a_dangling_symlinks_target_instead_of_refusing() {
     // BUG 4: the untracked-file backup loop called `fs::read(&src)`, which


### PR DESCRIPTION
`cargo test` did not fail on Windows — it never started. Two commits, and the second one is only reachable because of the first.

```
before:   0 passed,  0 failed
after:  682 passed, 19 failed
```

## 1. Nothing could run

Two separate things, and the aggregate hid both:

- **`tests/submodule.rs` did not compile.** Two tests used `std::os::unix` APIs unguarded. One non-compiling target makes `cargo test --no-fail-fast` emit no test results at all, which is why the whole command reported nothing rather than a partial run.
- **The library unit-test binary did not start.** It exited with `STATUS_ENTRYPOINT_NOT_FOUND` (0xC0000139) before the harness ran anything — taking `export_bindings`, the test that regenerates `src/ipc/bindings.ts`, down with it.

The second one is the interesting half. That binary imports `comctl32!TaskDialogIndirect`, which exists only in comctl32 **version 6**. `C:\Windows\System32\comctl32.dll` is v5 and does not export it; v6 lives in a side-by-side assembly the loader binds only for a process whose manifest declares `Microsoft.Windows.Common-Controls` 6.0.0.0. `tauri_build` embeds that manifest in the app binary, and nothing embeds it in a test binary.

Worth stating precisely, because it is easy to overstate: **exactly two binaries in the build carry comctl32 imports** — the app and the lib unit-test exe. `dumpbin /DEPENDENTS` over `target/debug/deps/*.exe` shows none of the 36 `tests/*.rs` binaries reference comctl32 at all, and a pre-change integration exe still on disk runs fine. The import comes from `tauri-runtime-wry`'s own `dialog/windows.rs`, compiled unconditionally on Windows, and from `muda`/`rfd` under the dialog plugin — so no feature flag drops it.

**Fixed by delay-loading comctl32** for `windows-msvc` targets. There is no way to reach only the test binaries, and all three alternatives were measured rather than assumed — the reasons are in `build.rs` so nobody has to repeat them:

| attempt | result |
|---|---|
| `cargo:rustc-link-arg-tests` | does not apply to the lib's own unit-test target. With it set, the built test exe carries no manifest at all; it covers `tests/*.rs` only |
| unscoped `cargo:rustc-link-arg` | reaches the test binary, but also the app, where `/MANIFEST:EMBED` collides with tauri-build's own manifest resource: `CVT1100: duplicate resource` then `LNK1123` |
| side-by-side `<exe>.manifest` | a build script cannot place it — it does not know the test binary's hashed filename |

The duplicate, not manifest embedding as such, is what blocks that route. `WindowsAttributes::new_without_app_manifest()` would also work by handing `build.rs` ownership of the app manifest; that is noted as the road not taken, with why.

**The app still binds v6** — verified by launching the built app and reading `Process.Modules`, where comctl32 resolves from the WinSxS 6.0 assembly. The cost is fail-fast becoming fail-late: if the app's manifest were ever lost, the old failure was a loader error at startup, and now it is an unhandled structured exception when a dialog opens. That trade is written down next to the flag rather than left for someone to discover.

## 2. The host's `core.autocrlf` decided whether tests passed

With the suite finally running, 88 failed. **69 of them were one setting.**

Git for Windows installs `core.autocrlf=true` by default, which rewrites LF to CRLF on every checkout. A test writes `"base\nline2\n"`, the code under test does something that re-checkouts the file, and the assertion compares against `"base\r\nline2\r\n"`. That was 58. Twelve more were the same cause wearing a different hat — `is_clean()` returning false, because git reports a file as modified when its line endings no longer match the index.

The fixture already takes some care to keep the host's config out of these repos (gpgsign, identity, gc), and `git()` neutralizes global/system config for its own invocations. What it could not cover is **the code under test**, which shells out to `git` itself with no such environment. So the setting has to live in the repo, where local config outranks the host's global.

`core.eol` as well as `core.autocrlf`: autocrlf alone leaves `eol` to decide the checkout form for paths a `.gitattributes` file marks as `text`, and some tests write one. Both are no-ops on Linux, where this is already the effective default.

`init_bare` deliberately does **not** get this — a bare repo has no working tree, so there is no checkout to convert, and setting it there would leave the next reader working out why.

The list also moved into `TempRepo::apply_test_config`, because `patch.rs`'s `clone_of` had hand-copied four of the five entries and drifted. A clone starts with none of its source's local config, and that stale copy is exactly why three patch tests still failed after the first pass. One list, two callers, no third copy to go stale.

## What is still red, and why it is not in here

Nineteen remain (twenty on some runs — one bisect test is timing-sensitive and flips). They are pre-existing and newly *visible*, not regressions: this is the first time any of them has been allowed to run. Each group has its own cause and its own fix shape, so they are filed separately rather than bundled into this PR:

- **8** (#99) — nested submodule repos inherit the host's `core.autocrlf`. Same root cause as above, but `git submodule add` clones the nested repo *inside the call under test*, so there is no moment to configure it from the test. Needs a different mechanism.
- **4** (#100) — `bisect`'s scripted good/bad command is a shell script; Windows has no shell to run it, so bisect converges on the wrong commit.
- **3** (#101) — three test-side assumptions that only hold on POSIX: a filename containing a tab (Windows cannot create it at all), an assertion comparing a raw path against the backslash-escaped form `git config` actually writes, and a rename target with no uniqueness in its name that nothing ever cleans up.
- **1** (#102) — the built-in terminal's ConPTY round-trip reads nothing from the PTY. Unexplained.

Four more failures on my machine were **not** a repo problem: `git-filter-repo` is not installed locally, and CI installs it with `pipx`. Mentioning it only so the count reconciles.

## CI

The Windows job stays compile-only, but its comment no longer claims the suite cannot compile or start — both of which it said, and neither of which is true any more. Turning the run on belongs with fixing the failures above; flipping it now would just make every PR red.

## Verified

`cargo build` links the app cleanly · `cargo test --lib` 255 passed / 1 failed (the ConPTY test) · `export_bindings` runs and leaves `src/ipc/bindings.ts` unchanged · `cargo clippy --lib` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
