### PR TITLE
Fix three POSIX assumptions in the test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,20 +188,24 @@ jobs:
   # otherwise unverified until a tagged release runs the 6-platform matrix. This
   # catches a Windows-only compile break on the PR instead.
   #
-  # Compile-only, on purpose:
+  # Compile-only, on purpose — but the reason changed, so read this before
+  # assuming it still can't run:
   #  - `cargo build` covers the app/library binary.
   #  - `cargo test --lib --no-run` additionally COMPILES the library unit-test
-  #    code on Windows (Windows-clean: the handful of Unix-only cases are
-  #    #[cfg(unix)]-guarded), catching a Windows test-compile break too. `--lib`
-  #    skips the tests/ integration suite (submodule / repo_registry /
-  #    repo_files), which uses unguarded std::os::unix APIs and doesn't compile
-  #    on Windows yet (a separate follow-up).
-  #  - We deliberately do NOT run the tests. The Tauri library's test binary
-  #    transitively links the WebView2/wry native stack and fails to resolve a
-  #    DLL entry point at startup on a stock runner (exit 0xc0000139,
-  #    STATUS_ENTRYPOINT_NOT_FOUND) before any test executes. The cli_shim
-  #    launcher tests are platform-agnostic pure functions already run by the
-  #    Linux `rust` job, so running them here would add nothing regardless.
+  #    code on Windows, catching a Windows test-compile break too.
+  #  - The whole test suite now COMPILES on Windows, and the library test
+  #    binary now STARTS. It used to die at startup with exit 0xc0000139
+  #    (STATUS_ENTRYPOINT_NOT_FOUND) before any test ran, because it imports a
+  #    comctl32 v6 export without the manifest that binds v6; build.rs
+  #    delay-loads comctl32 to fix that, and the two remaining Unix-only cases
+  #    in tests/submodule.rs are #[cfg(unix)]-guarded.
+  #  - We still do NOT run the tests here, and that is now a real choice rather
+  #    than an impossibility. Locally the suite is 613 passed / 88 failed on
+  #    Windows: one library test (a ConPTY round-trip that reads nothing) plus
+  #    an integration cluster concentrated in workdir/merge/rebase/submodule.
+  #    Those are pre-existing Windows gaps that have never been allowed to run
+  #    before, not regressions. Turning the run on is a follow-up that belongs
+  #    with fixing them — flipping it now would just make every PR red.
   # No apt/system-deps step: Windows runners ship the MSVC toolchain and WebView2
   # SDK, and libgit2-sys builds its vendored copy with `cc`, same as on Linux.
   rust-windows:

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,5 +8,88 @@ fn main() {
     // reports "Compiling gitcat". Watch the whole icons/ directory so any
     // icon regeneration always re-embeds correctly.
     println!("cargo:rerun-if-changed=icons");
+    delay_load_comctl32_on_windows();
     tauri_build::build()
+}
+
+/// Let the library's unit-test binary START on Windows.
+///
+/// It could not. `cargo test --lib` exited with STATUS_ENTRYPOINT_NOT_FOUND
+/// (0xC0000139) before the harness ran anything, which took `export_bindings`
+/// — the test that regenerates `src/ipc/bindings.ts` — down with it. CI runs
+/// the Rust suite on Linux, so nothing caught it.
+///
+/// Cause: this binary imports `comctl32!TaskDialogIndirect`, which exists only
+/// in comctl32 **version 6**. `C:\Windows\System32\comctl32.dll` is v5 and does
+/// not export it; v6 lives in a side-by-side assembly the loader binds only for
+/// a process whose manifest declares a `Microsoft.Windows.Common-Controls`
+/// 6.0.0.0 dependency. `tauri_build` embeds that manifest in the APP binary and
+/// nothing embeds it in a test binary.
+///
+/// Scope, since the shape of this is easy to overstate: exactly TWO binaries in
+/// the build carry comctl32 imports — the app and the lib unit-test exe.
+/// `dumpbin /DEPENDENTS` over `target/debug/deps/*.exe` shows none of the
+/// `tests/*.rs` integration binaries reference comctl32 at all, and a
+/// pre-change integration exe still runs. What made the whole command report
+/// `0 passed, 0 failed` was the separate compile error in `tests/submodule.rs`
+/// (now `cfg(unix)`-gated): one non-compiling target makes `cargo test
+/// --no-fail-fast` emit no test results whatsoever.
+///
+/// The import comes from `tauri-runtime-wry`'s own `dialog/windows.rs`, which
+/// is compiled unconditionally on Windows, and from `muda`/`rfd` under the
+/// dialog plugin — so it is not something a feature flag can drop.
+///
+/// ## Why delay-loading rather than embedding the manifest
+///
+/// There is no way to reach only the test binaries. All three alternatives
+/// were measured, so nobody has to repeat them:
+///
+/// - `cargo:rustc-link-arg-tests` does NOT apply to the lib's own unit-test
+///   target — the one that needs it. It covers `tests/*.rs` only. (Measured
+///   with `/VERSION:7.7`: the integration exe is stamped, the lib-test exe is
+///   not.)
+/// - The unscoped `cargo:rustc-link-arg` does reach it, but also reaches the
+///   app, where `/MANIFEST:EMBED` collides with the manifest resource
+///   tauri-build already generated: `CVT1100: duplicate resource.
+///   type:MANIFEST, name:1` then `LNK1123`. `/MANIFESTINPUT` without
+///   `/MANIFEST:EMBED` is `LNK1220`, so the pair cannot be split.
+/// - A side-by-side `<exe>.manifest` is not something a build script can
+///   place: it cannot know the test binary's hashed filename.
+///
+/// The duplicate — not manifest embedding as such — is what blocks that route.
+/// `tauri_build::WindowsAttributes::new_without_app_manifest()` would hand this
+/// file ownership of the app manifest and let an unscoped `/MANIFEST:EMBED`
+/// cover every target, keeping the app statically bound. That is a real option,
+/// deliberately not taken: it makes this build script responsible for a
+/// manifest tauri-build generates and evolves, which is a standing maintenance
+/// cost for a test-only problem.
+///
+/// ## What delay-loading costs
+///
+/// The app still gets v6: its manifest is in force by the time the DLL is
+/// actually loaded (verified by launching the built app and reading
+/// `Process.Modules` — comctl32 resolves from the WinSxS 6.0 assembly). The
+/// tests never call `TaskDialogIndirect`, so the import is never resolved and
+/// the process starts.
+///
+/// The trade is fail-fast for fail-late. If the app's manifest were ever lost
+/// — a tauri-build upgrade, a bundler or re-signing step that rewrites
+/// resources — the old behaviour was a loader error at startup, before any user
+/// data was in play. Now it is an unhandled structured exception
+/// (`0xC06D007F`) at the moment a dialog opens. Worth knowing before blaming
+/// the dialog code.
+fn delay_load_comctl32_on_windows() {
+    // TARGET, not HOST: a Windows cross-build from Linux still needs this, and
+    // a Linux build hosted on Windows must not get MSVC linker flags. Both
+    // shipped Windows targets are `*-pc-windows-msvc` (see release.yml);
+    // `*-pc-windows-gnu` is deliberately excluded, since these are MSVC-only
+    // flags — a GNU-toolchain Windows build is not something this repo ships,
+    // and would need its own answer.
+    if !std::env::var("TARGET").unwrap_or_default().contains("windows-msvc") {
+        return;
+    }
+    println!("cargo:rustc-link-arg=/DELAYLOAD:comctl32.dll");
+    // Provides __delayLoadHelper2, which the delay-load stubs call. Without it
+    // the link fails with LNK2001 on that symbol.
+    println!("cargo:rustc-link-arg=delayimp.lib");
 }

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -45,13 +45,28 @@ impl TempRepo {
         std::fs::create_dir_all(&dir).expect("mkdir temp repo");
         let repo = TempRepo { dir };
         repo.must(&["init", "-q", "-b", "main"]);
+        repo.apply_test_config();
+        repo
+    }
+
+    /// The repo-LOCAL config every throwaway working-tree repo needs, in one
+    /// place because there is more than one way a test builds one: `init`
+    /// above, and `patch.rs`'s `clone_of`, which used to hand-copy a subset of
+    /// this list and drifted out of sync with it.
+    ///
+    /// Everything here is set LOCALLY on purpose. `git()` below neutralizes the
+    /// host's global/system config for its OWN invocations, but the code under
+    /// test shells out to `git` itself with no such environment — so anything
+    /// that must hold for the code under test has to live in the repo, where it
+    /// outranks the host's global config.
+    pub fn apply_test_config(&self) {
         // CRITICAL: without this, a commit hangs forever on a GPG passphrase prompt.
-        repo.must(&["config", "commit.gpgsign", "false"]);
+        self.must(&["config", "commit.gpgsign", "false"]);
         // Separate config key from commit.gpgsign — needed once a test creates
         // an annotated tag (`git tag -a`, e.g. tests/plumbing.rs); without this,
         // a host with tag signing defaulted on would hang the ENTIRE shared
         // test binary (this file is `mod common`'d by every tests/*.rs file).
-        repo.must(&["config", "tag.gpgsign", "false"]);
+        self.must(&["config", "tag.gpgsign", "false"]);
         // CRITICAL: repo-LOCAL identity, independent of any GIT_AUTHOR_*/GIT_COMMITTER_*
         // env vars (see `git()` below) or the machine's global/system git config. Code
         // under test (e.g. git_pick::cherry_pick_continue) shells out to git directly
@@ -63,16 +78,35 @@ impl TempRepo {
         // config sits above that fallback and below explicit env vars in git's identity
         // resolution, so this makes every throwaway repo self-sufficient regardless of
         // the host's global config or GECOS data.
-        repo.must(&["config", "user.name", "GitCat Test"]);
-        repo.must(&["config", "user.email", "test@gitcat.example"]);
+        self.must(&["config", "user.name", "GitCat Test"]);
+        self.must(&["config", "user.email", "test@gitcat.example"]);
+        // Line endings, for the same reason as the identity above: Git for
+        // Windows installs `core.autocrlf=true` by default, which rewrites LF to
+        // CRLF on every checkout. A test writes "base\nline2\n", the code under
+        // test performs an operation that re-checkouts the file, and the
+        // assertion then compares against "base\r\nline2\r\n" — 58 failures on a
+        // Windows host, all of them the test being platform-naive rather than
+        // anything being wrong. Twelve more showed up as `is_clean()` returning
+        // false, the same cause wearing a different hat: git reports a file as
+        // modified when its line endings no longer match what the index expects.
+        //
+        // `core.eol` as well as autocrlf: autocrlf alone still leaves `eol` to
+        // decide the checkout form for paths marked `text` by a .gitattributes
+        // file, and some tests write one.
+        //
+        // This does NOT mean the app is untested against CRLF working trees —
+        // it means these assertions are about git plumbing, not about line
+        // endings, and a real user's autocrlf setting has no business deciding
+        // whether they pass.
+        self.must(&["config", "core.autocrlf", "false"]);
+        self.must(&["config", "core.eol", "lf"]);
         // Disable background auto-gc/maintenance: a test that creates MANY commits
         // rapidly (dashboard's `stays_cheap_…` runs a 300-commit loop) otherwise
         // intermittently trips `git gc --auto` repacking behind the next commit —
         // observed as a flaky CI failure "error: bad tree object HEAD" mid-loop.
         // No test needs gc, so turn it off outright for every throwaway repo.
-        repo.must(&["config", "gc.auto", "0"]);
-        repo.must(&["config", "maintenance.auto", "false"]);
-        repo
+        self.must(&["config", "gc.auto", "0"]);
+        self.must(&["config", "maintenance.auto", "false"]);
     }
 
     /// A bare repo (no working tree) — stands in for a real remote in

--- a/src-tauri/tests/patch.rs
+++ b/src-tauri/tests/patch.rs
@@ -37,10 +37,11 @@ fn clone_of(src: &TempRepo, tag: &str) -> TempRepo {
         .expect("failed to spawn git clone");
     assert!(out.status.success(), "git clone failed: {}", String::from_utf8_lossy(&out.stderr));
     let repo = TempRepo { dir };
-    repo.must(&["config", "commit.gpgsign", "false"]);
-    repo.must(&["config", "tag.gpgsign", "false"]);
-    repo.must(&["config", "user.name", "GitCat Test"]);
-    repo.must(&["config", "user.email", "test@gitcat.example"]);
+    // A clone starts with none of the source repo's local config, so it needs
+    // the same treatment `TempRepo::init` gives. This used to be a hand-copied
+    // subset of that list, which is how it ended up missing the line-ending
+    // settings and failing three tests on Windows.
+    repo.apply_test_config();
     repo
 }
 

--- a/src-tauri/tests/submodule.rs
+++ b/src-tauri/tests/submodule.rs
@@ -1048,8 +1048,16 @@ fn submodule_sync_rewrites_git_config_url_after_gitmodules_is_hand_edited() {
     parent.must(&["commit", "-q", "-m", "point sub at a new home"]);
 
     // Confirm the split BEFORE syncing: .gitmodules moved, .git/config did not.
-    let gitmodules = parent.read(".gitmodules");
-    assert!(gitmodules.contains(&child_new.path()), "expected .gitmodules to record the new url");
+    //
+    // Read the value back through `git config` rather than substring-matching
+    // the file's text. `git config` ESCAPES backslashes when it writes a value,
+    // so a Windows path lands in the file doubled —
+    // `url = C:\\Users\\…\\child` — and a `contains(path)` on the raw text can
+    // never match. Reading it back also makes the assertion about the recorded
+    // VALUE rather than about the file's formatting, which is what this line
+    // was always trying to say.
+    let (_, gitmodules_url, _) = parent.git(&["config", "--get", "-f", ".gitmodules", "submodule.sub.url"]);
+    assert_eq!(gitmodules_url, child_new.path(), "expected .gitmodules to record the new url");
     let (_, url_still_stale, _) = parent.git(&["config", "--get", "submodule.sub.url"]);
     assert_eq!(url_still_stale, child.path(), ".git/config must still be stale before sync runs");
 
@@ -1284,8 +1292,22 @@ fn submodule_deinit_recovers_offline_via_init_and_update() {
 
     // Simulate the original source repo becoming permanently unreachable
     // (moved/deleted) — the offline-recovery property must not depend on it.
-    let moved_away = child.dir.with_file_name("submodule_deinit_offline_child_GONE");
+    //
+    // The destination name is derived from `child`'s own directory, which
+    // already carries pid + nanos + a counter. It used to be a FIXED string,
+    // which made this test poison itself: once the rename succeeded, nothing
+    // owned the result — `child`'s Drop removes `child.dir`, which no longer
+    // exists — so the renamed repo leaked into the temp dir, and every later
+    // run then hit `rename` onto an existing non-empty directory (ENOTEMPTY on
+    // unix, ERROR_DIR_NOT_EMPTY on Windows). CI never saw it because a fresh
+    // runner always starts with an empty temp dir.
+    let moved_away = child.dir.with_file_name(format!(
+        "{}-GONE",
+        child.dir.file_name().expect("temp repo dir has a final component").to_string_lossy()
+    ));
     std::fs::rename(&child.dir, &moved_away).expect("simulate the origin going away");
+    // Hand the renamed directory to a TempRepo purely so its Drop cleans up.
+    let _moved_away_owner = TempRepo { dir: moved_away.clone() };
 
     // init re-registers the (now-unreachable) url from .gitmodules — this
     // never dereferences the url, so it succeeds regardless.

--- a/src-tauri/tests/submodule.rs
+++ b/src-tauri/tests/submodule.rs
@@ -1752,6 +1752,11 @@ fn bug2_remove_refuses_when_a_nested_submodule_of_a_submodule_is_dirty() {
     assert!(!status_after.contains("D  sub"), "sub's gitlink must not have been staged for deletion: {status_after:?}");
 }
 
+// Unix-only: the precondition is a read-only DIRECTORY, which is what makes
+// the `.gitmodules` rewrite fail. Windows ignores the read-only attribute for
+// that purpose — there is no equivalent using file attributes, and an ACL deny
+// would be more machinery than this test is worth.
+#[cfg(unix)]
 #[test]
 fn bug3_remove_propagates_a_failed_gitmodules_fallback_instead_of_reporting_ok() {
     // BUG 3: the `.gitmodules` section-removal fallback (for when `git rm -f`
@@ -1804,6 +1809,9 @@ fn bug3_remove_propagates_a_failed_gitmodules_fallback_instead_of_reporting_ok()
     );
 }
 
+// Unix-only: needs a dangling symlink, which on Windows requires either
+// Developer Mode or elevation — not something a test run can assume.
+#[cfg(unix)]
 #[test]
 fn bug4_force_deinit_backs_up_a_dangling_symlinks_target_instead_of_refusing() {
     // BUG 4: the untracked-file backup loop called `fs::read(&src)`, which

--- a/src-tauri/tests/workdir.rs
+++ b/src-tauri/tests/workdir.rs
@@ -723,6 +723,12 @@ fn discard_file_reverses_an_unstaged_rename() {
 // reject only NUL/CR/LF, not every control character (e.g. a legitimate tab).
 // ---------------------------------------------------------------------------
 
+// Unix-only: a tab is not a legal character in a Windows filename, so the file
+// this test needs cannot be created there at all (`std::fs::write` fails with
+// ERROR_INVALID_NAME). The behaviour under test — that `stage_file` does not
+// reject a path git itself accepts — is unchanged on Windows; there is simply
+// no way to construct the input.
+#[cfg(unix)]
 #[test]
 fn stage_file_accepts_a_tab_containing_filename() {
     let repo = TempRepo::init("workdir_tab_filename");


### PR DESCRIPTION
Closes #101.

**Stacked on #98** — these tests cannot run on Windows without it, so the diff will show that PR's two commits until it merges. Only `0b55028` belongs to this one.

19 → 18 failing on Windows, and one test stops poisoning every later run on the same machine.

## A tab in a filename

`stage_file_accepts_a_tab_containing_filename` cannot build its input on Windows: a tab is not a legal filename character there, so `std::fs::write` fails with `ERROR_INVALID_NAME` before the assertion is reached. The behaviour under test — that `stage_file` accepts a path git itself accepts — is unchanged on Windows; there is just no way to construct the case.

`#[cfg(unix)]`, in the same shape as the two POSIX-only cases already gated in `tests/submodule.rs`.

## An assertion comparing a raw path to what `git config` actually writes

`submodule_sync_rewrites_git_config_url_after_gitmodules_is_hand_edited` substring-matched `.gitmodules`'s text for a path. `git config` escapes backslashes when it writes a value, so a Windows path lands doubled — reproduced directly:

```
$ git config -f .gitmodules submodule.sub.url 'C:\Temp\GitCat\child'
$ cat .gitmodules
[submodule "sub"]
        url = C:\Temp\GitCat\child
```

`contains(&child_new.path())` looks for the single-backslash form and can never match. It now reads the value back with `git config --get -f`, which unescapes — and which also makes the assertion about the recorded *value* rather than about the file's formatting, which is what the line was trying to say in the first place.

## A rename target with no uniqueness, that nothing cleaned up

`submodule_deinit_recovers_offline_via_init_and_update` renamed the child repo to a **fixed** name to simulate the origin vanishing:

```rust
let moved_away = child.dir.with_file_name("submodule_deinit_offline_child_GONE");
```

Every other temp path in the suite carries pid + nanos + a counter. This one did not — and once the rename succeeded, nothing owned the result: `child`'s `Drop` removes `child.dir`, which by then no longer exists, so the renamed repo leaked into the temp dir.

From that point on, every later run failed, because `rename` onto an existing non-empty directory is an error (`ENOTEMPTY` on unix, `ERROR_DIR_NOT_EMPTY` on Windows). CI never sees it — a fresh runner always starts with an empty temp dir. I found the leaked repo sitting in mine, 42 entries deep.

The target is now derived from the child's own unique directory name, and handed to a `TempRepo` so `Drop` cleans it up.

### Correcting the issue on this one

#101 says the `ERROR_DIR_NOT_EMPTY` was not fully explained, because deleting the leaked directory by hand did not appear to help. With the unique name in place the rename succeeds, so the leftover **was** the whole cause — my manual delete evidently had not taken effect before that run. I would rather correct that here than leave a wrong note standing in the issue.

That test still fails, but now on `"hello\r\n"` vs `"hello\n"`: it has become one of #99's nested-submodule CRLF cases. Different issue, not touched here.

## Verified

On Windows: `--test workdir` 40 passed / 0 failed (was one failing), `--test submodule` 40 passed / 9 failed (was 10). Full suite 682 passed / 18 failed.

Nothing here changes behaviour on unix: the gate only excludes, the `git config` read is equivalent where paths contain no backslashes, and the rename target is merely unique now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
