### PR TITLE
Answer ConPTY's cursor-position query, as a terminal must

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,20 +188,24 @@ jobs:
   # otherwise unverified until a tagged release runs the 6-platform matrix. This
   # catches a Windows-only compile break on the PR instead.
   #
-  # Compile-only, on purpose:
+  # Compile-only, on purpose — but the reason changed, so read this before
+  # assuming it still can't run:
   #  - `cargo build` covers the app/library binary.
   #  - `cargo test --lib --no-run` additionally COMPILES the library unit-test
-  #    code on Windows (Windows-clean: the handful of Unix-only cases are
-  #    #[cfg(unix)]-guarded), catching a Windows test-compile break too. `--lib`
-  #    skips the tests/ integration suite (submodule / repo_registry /
-  #    repo_files), which uses unguarded std::os::unix APIs and doesn't compile
-  #    on Windows yet (a separate follow-up).
-  #  - We deliberately do NOT run the tests. The Tauri library's test binary
-  #    transitively links the WebView2/wry native stack and fails to resolve a
-  #    DLL entry point at startup on a stock runner (exit 0xc0000139,
-  #    STATUS_ENTRYPOINT_NOT_FOUND) before any test executes. The cli_shim
-  #    launcher tests are platform-agnostic pure functions already run by the
-  #    Linux `rust` job, so running them here would add nothing regardless.
+  #    code on Windows, catching a Windows test-compile break too.
+  #  - The whole test suite now COMPILES on Windows, and the library test
+  #    binary now STARTS. It used to die at startup with exit 0xc0000139
+  #    (STATUS_ENTRYPOINT_NOT_FOUND) before any test ran, because it imports a
+  #    comctl32 v6 export without the manifest that binds v6; build.rs
+  #    delay-loads comctl32 to fix that, and the two remaining Unix-only cases
+  #    in tests/submodule.rs are #[cfg(unix)]-guarded.
+  #  - We still do NOT run the tests here, and that is now a real choice rather
+  #    than an impossibility. Locally the suite is 613 passed / 88 failed on
+  #    Windows: one library test (a ConPTY round-trip that reads nothing) plus
+  #    an integration cluster concentrated in workdir/merge/rebase/submodule.
+  #    Those are pre-existing Windows gaps that have never been allowed to run
+  #    before, not regressions. Turning the run on is a follow-up that belongs
+  #    with fixing them — flipping it now would just make every PR red.
   # No apt/system-deps step: Windows runners ship the MSVC toolchain and WebView2
   # SDK, and libgit2-sys builds its vendored copy with `cc`, same as on Linux.
   rust-windows:

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,5 +8,88 @@ fn main() {
     // reports "Compiling gitcat". Watch the whole icons/ directory so any
     // icon regeneration always re-embeds correctly.
     println!("cargo:rerun-if-changed=icons");
+    delay_load_comctl32_on_windows();
     tauri_build::build()
+}
+
+/// Let the library's unit-test binary START on Windows.
+///
+/// It could not. `cargo test --lib` exited with STATUS_ENTRYPOINT_NOT_FOUND
+/// (0xC0000139) before the harness ran anything, which took `export_bindings`
+/// — the test that regenerates `src/ipc/bindings.ts` — down with it. CI runs
+/// the Rust suite on Linux, so nothing caught it.
+///
+/// Cause: this binary imports `comctl32!TaskDialogIndirect`, which exists only
+/// in comctl32 **version 6**. `C:\Windows\System32\comctl32.dll` is v5 and does
+/// not export it; v6 lives in a side-by-side assembly the loader binds only for
+/// a process whose manifest declares a `Microsoft.Windows.Common-Controls`
+/// 6.0.0.0 dependency. `tauri_build` embeds that manifest in the APP binary and
+/// nothing embeds it in a test binary.
+///
+/// Scope, since the shape of this is easy to overstate: exactly TWO binaries in
+/// the build carry comctl32 imports — the app and the lib unit-test exe.
+/// `dumpbin /DEPENDENTS` over `target/debug/deps/*.exe` shows none of the
+/// `tests/*.rs` integration binaries reference comctl32 at all, and a
+/// pre-change integration exe still runs. What made the whole command report
+/// `0 passed, 0 failed` was the separate compile error in `tests/submodule.rs`
+/// (now `cfg(unix)`-gated): one non-compiling target makes `cargo test
+/// --no-fail-fast` emit no test results whatsoever.
+///
+/// The import comes from `tauri-runtime-wry`'s own `dialog/windows.rs`, which
+/// is compiled unconditionally on Windows, and from `muda`/`rfd` under the
+/// dialog plugin — so it is not something a feature flag can drop.
+///
+/// ## Why delay-loading rather than embedding the manifest
+///
+/// There is no way to reach only the test binaries. All three alternatives
+/// were measured, so nobody has to repeat them:
+///
+/// - `cargo:rustc-link-arg-tests` does NOT apply to the lib's own unit-test
+///   target — the one that needs it. It covers `tests/*.rs` only. (Measured
+///   with `/VERSION:7.7`: the integration exe is stamped, the lib-test exe is
+///   not.)
+/// - The unscoped `cargo:rustc-link-arg` does reach it, but also reaches the
+///   app, where `/MANIFEST:EMBED` collides with the manifest resource
+///   tauri-build already generated: `CVT1100: duplicate resource.
+///   type:MANIFEST, name:1` then `LNK1123`. `/MANIFESTINPUT` without
+///   `/MANIFEST:EMBED` is `LNK1220`, so the pair cannot be split.
+/// - A side-by-side `<exe>.manifest` is not something a build script can
+///   place: it cannot know the test binary's hashed filename.
+///
+/// The duplicate — not manifest embedding as such — is what blocks that route.
+/// `tauri_build::WindowsAttributes::new_without_app_manifest()` would hand this
+/// file ownership of the app manifest and let an unscoped `/MANIFEST:EMBED`
+/// cover every target, keeping the app statically bound. That is a real option,
+/// deliberately not taken: it makes this build script responsible for a
+/// manifest tauri-build generates and evolves, which is a standing maintenance
+/// cost for a test-only problem.
+///
+/// ## What delay-loading costs
+///
+/// The app still gets v6: its manifest is in force by the time the DLL is
+/// actually loaded (verified by launching the built app and reading
+/// `Process.Modules` — comctl32 resolves from the WinSxS 6.0 assembly). The
+/// tests never call `TaskDialogIndirect`, so the import is never resolved and
+/// the process starts.
+///
+/// The trade is fail-fast for fail-late. If the app's manifest were ever lost
+/// — a tauri-build upgrade, a bundler or re-signing step that rewrites
+/// resources — the old behaviour was a loader error at startup, before any user
+/// data was in play. Now it is an unhandled structured exception
+/// (`0xC06D007F`) at the moment a dialog opens. Worth knowing before blaming
+/// the dialog code.
+fn delay_load_comctl32_on_windows() {
+    // TARGET, not HOST: a Windows cross-build from Linux still needs this, and
+    // a Linux build hosted on Windows must not get MSVC linker flags. Both
+    // shipped Windows targets are `*-pc-windows-msvc` (see release.yml);
+    // `*-pc-windows-gnu` is deliberately excluded, since these are MSVC-only
+    // flags — a GNU-toolchain Windows build is not something this repo ships,
+    // and would need its own answer.
+    if !std::env::var("TARGET").unwrap_or_default().contains("windows-msvc") {
+        return;
+    }
+    println!("cargo:rustc-link-arg=/DELAYLOAD:comctl32.dll");
+    // Provides __delayLoadHelper2, which the delay-load stubs call. Without it
+    // the link fails with LNK2001 on that symbol.
+    println!("cargo:rustc-link-arg=delayimp.lib");
 }

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -243,7 +243,28 @@ mod tests {
         let repo = TempGitDir::init();
         let mut session = open_pty_shell(&repo.path()).expect("should spawn a real shell");
         let mut reader = session.master.try_clone_reader().expect("should clone a reader");
-        session.writer.write_all(b"echo hello_gitcat_terminal\n").expect("should write to the shell");
+
+        // Play enough of a terminal for the shell to start talking.
+        //
+        // ConPTY opens by asking the terminal where its cursor is — a Device
+        // Status Report, `ESC[6n` — and BLOCKS until something answers. In the
+        // app xterm.js answers automatically, which is why the drawer works;
+        // this test IS the terminal, and answering is not optional. Measured:
+        // without the reply the master side yields exactly those four bytes
+        // and nothing else — not even cmd.exe's banner — however long you
+        // wait. With it, ~290 bytes arrive at once: banner, prompt, echo, all.
+        //
+        // Windows-only on purpose. No unix pty asks this, and there the escape
+        // would not be consumed by anything — it would land in the line buffer
+        // and end up prefixed to the command, which happens to still satisfy
+        // the assertion below (via the shell's "not found" message quoting it)
+        // while testing nothing at all.
+        #[cfg(windows)]
+        session.writer.write_all(b"\x1b[1;1R").expect("should answer the cursor-position query");
+        // CRLF, not LF: cmd.exe submits a line on CR. A unix pty translates CR
+        // to NL on input (ICRNL), so this reads the same on both.
+        session.writer.write_all(b"echo hello_gitcat_terminal\r\n").expect("should write to the shell");
+        session.writer.flush().expect("should flush");
 
         let (tx, rx) = std::sync::mpsc::channel::<String>();
         std::thread::spawn(move || {

--- a/src-tauri/tests/bisect.rs
+++ b/src-tauri/tests/bisect.rs
@@ -13,11 +13,17 @@ mod common;
 
 use common::TempRepo;
 use git2::{Oid, Repository, RepositoryState};
-use gitcat_lib::git_bisect::{
-    bisect_mark, bisect_reset, bisect_start, bisect_status, run_bisect, try_run_bisect, BisectRunState, BisectStatus,
-};
+use gitcat_lib::git_bisect::{bisect_mark, bisect_reset, bisect_start, bisect_status, run_bisect, BisectStatus};
+// Used only by the #[cfg(unix)] automated-run tests below, so gated with them —
+// see the note above `bisect_run_handles_a_skip_exit_code_and_still_converges`
+// for why those three cannot run on Windows.
+#[cfg(unix)]
+use gitcat_lib::git_bisect::{try_run_bisect, BisectRunState};
+#[cfg(unix)]
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(unix)]
 use std::sync::Arc;
+#[cfg(unix)]
 use std::time::{Duration, Instant};
 
 const N: usize = 15;
@@ -173,8 +179,16 @@ fn bisect_run_converges_via_scripted_good_bad_command() {
 
     // Deterministic stand-in for a real regression test: "good" (exit 0) iff
     // bug.txt (introduced at K and present in every descendant) is absent.
+    //
+    // Written to run under BOTH shells `run_test_command` uses — `sh -c` on
+    // unix, `cmd /C` on Windows. `test ! -f` is a POSIX builtin cmd.exe does
+    // not have; `git cat-file -e` is the same question asked of a program both
+    // shells can run, and `&&`/`||`/`exit` mean the same thing in each. During
+    // a bisect the working tree matches HEAD, so asking HEAD is equivalent to
+    // asking the filesystem.
     let mut progress_calls = 0usize;
-    let result: BisectStatus = run_bisect(&path, "test ! -f bug.txt", || false, |_status| progress_calls += 1);
+    let judge = "git cat-file -e HEAD:bug.txt && exit 1 || exit 0";
+    let result: BisectStatus = run_bisect(&path, judge, || false, |_status| progress_calls += 1);
 
     assert!(result.first_bad.is_some(), "automated run did not converge: {}", result.message);
     assert_eq!(
@@ -197,6 +211,19 @@ fn bisect_run_converges_via_scripted_good_bad_command() {
     assert!(repo.is_clean(), "working tree dirty after reset");
 }
 
+// Unix-only, and not because the code under test is: `run_bisect` handles
+// Windows fine (`run_test_command` shells out through `cmd /C` there). It
+// is the SCAFFOLDING that has no portable form. This judge command needs
+// two things from its shell — state that survives between separate
+// invocations (a marker file), and a bounded block so the main thread can
+// observe the run mid-flight — and there is no spelling of those that both
+// `sh -c` and `cmd /C` accept. cmd has no `sleep`, and `timeout /t` needs a
+// console this deliberately does not give it (see `no_console_window`).
+//
+// The convergence test above IS portable and does cover the run loop on
+// Windows. What is uncovered here is skip handling, cancellation and the
+// concurrency refusal. See #100.
+#[cfg(unix)]
 #[test]
 fn bisect_run_handles_a_skip_exit_code_and_still_converges() {
     std::env::set_var("LC_ALL", "C");
@@ -307,6 +334,19 @@ fn bisect_run_refuses_cleanly_when_no_bisect_is_in_progress() {
     );
 }
 
+// Unix-only, and not because the code under test is: `run_bisect` handles
+// Windows fine (`run_test_command` shells out through `cmd /C` there). It
+// is the SCAFFOLDING that has no portable form. This judge command needs
+// two things from its shell — state that survives between separate
+// invocations (a marker file), and a bounded block so the main thread can
+// observe the run mid-flight — and there is no spelling of those that both
+// `sh -c` and `cmd /C` accept. cmd has no `sleep`, and `timeout /t` needs a
+// console this deliberately does not give it (see `no_console_window`).
+//
+// The convergence test above IS portable and does cover the run loop on
+// Windows. What is uncovered here is skip handling, cancellation and the
+// concurrency refusal. See #100.
+#[cfg(unix)]
 #[test]
 fn bisect_run_cancel_stops_the_loop_before_convergence() {
     std::env::set_var("LC_ALL", "C");
@@ -375,6 +415,19 @@ fn bisect_run_cancel_stops_the_loop_before_convergence() {
 // — same reasoning as testing `run_bisect` directly above. Coordination via
 // a marker-file side channel mirrors `bisect_run_cancel_stops_the_loop_
 // before_convergence` above exactly.
+// Unix-only, and not because the code under test is: `run_bisect` handles
+// Windows fine (`run_test_command` shells out through `cmd /C` there). It
+// is the SCAFFOLDING that has no portable form. This judge command needs
+// two things from its shell — state that survives between separate
+// invocations (a marker file), and a bounded block so the main thread can
+// observe the run mid-flight — and there is no spelling of those that both
+// `sh -c` and `cmd /C` accept. cmd has no `sleep`, and `timeout /t` needs a
+// console this deliberately does not give it (see `no_console_window`).
+//
+// The convergence test above IS portable and does cover the run loop on
+// Windows. What is uncovered here is skip handling, cancellation and the
+// concurrency refusal. See #100.
+#[cfg(unix)]
 #[test]
 fn bisect_run_start_refuses_a_second_concurrent_call_while_one_is_in_flight() {
     std::env::set_var("LC_ALL", "C");

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -20,6 +20,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Process-wide monotonic tie-breaker: several tests (or several #[test] fns
@@ -27,6 +28,57 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// `SystemTime::now()` within the same clock tick, so pid+nanos alone is not
 /// always unique — this closes that race deterministically.
 static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A git config file this test binary owns, pointed at by `GIT_CONFIG_GLOBAL`
+/// for the WHOLE PROCESS — so that every `git` run during the test run reads
+/// it, including the ones the code under test spawns for itself.
+///
+/// Repo-local config cannot cover those. `git submodule add` clones the child
+/// into an independent repository, and it does so *inside* the call under
+/// test, so there is no moment for a test to configure that repo before its
+/// working tree is written. On a host with Git for Windows' default
+/// `core.autocrlf=true`, nine `tests/submodule.rs` assertions then compared
+/// `"hello\n"` against the `"hello\r\n"` git had just legitimately written.
+///
+/// This also subsumes the `/dev/null` the `git()` helper used to point at: an
+/// empty-but-for-our-own-keys file blocks the host's `rerere.autoupdate` and
+/// friends exactly as well, and now there is one answer to "which global
+/// config does a test see" rather than two.
+///
+/// Named per-pid rather than uniquely: it is a ~40-byte file, one per test
+/// binary, overwritten on pid reuse. Nothing owns it to clean it up, which is
+/// a deliberate trade for a fixed-size file — unlike a leaked repo tree, it
+/// cannot poison a later run.
+fn global_git_config() -> &'static PathBuf {
+    static PATH: OnceLock<PathBuf> = OnceLock::new();
+    PATH.get_or_init(|| {
+        let path = std::env::temp_dir().join(format!("gitcat-test-gitconfig-{}", std::process::id()));
+        std::fs::write(
+            &path,
+            // autocrlf off so nothing is rewritten on checkout; eol=lf because
+            // autocrlf alone leaves `eol` (default: native) to decide the
+            // checkout form for paths a .gitattributes marks as `text`.
+            "[core]\n\tautocrlf = false\n\teol = lf\n",
+        )
+        .expect("write the test-run git config");
+        // Set for the process, not per-command: the whole point is to reach
+        // git invocations this fixture never makes, so there is no command
+        // line to put it on.
+        //
+        // `set_var` in a multi-threaded process is the known-sharp part. It is
+        // mitigated rather than eliminated: OnceLock makes it happen exactly
+        // once, and every test's first act is building a TempRepo, so the
+        // write lands before that thread spawns any git. A thread already
+        // mid-spawn when the very first test initializes could in principle
+        // miss it — in practice the first TempRepo is constructed before any
+        // test has reached the code under test. If this ever does flake, the
+        // fix is to hoist it into a `#[ctor]`-style pre-main rather than to
+        // paper over it here.
+        std::env::set_var("GIT_CONFIG_GLOBAL", &path);
+        std::env::set_var("GIT_CONFIG_SYSTEM", &path);
+        path
+    })
+}
 
 /// A disposable git repository under the OS temp dir. Auto-removed on `Drop`.
 pub struct TempRepo {
@@ -43,6 +95,7 @@ impl TempRepo {
         let dir = std::env::temp_dir()
             .join(format!("gitcat-test-{tag}-{}-{}-{}", std::process::id(), nanos, seq));
         std::fs::create_dir_all(&dir).expect("mkdir temp repo");
+        global_git_config(); // before the first git of the run — see its doc
         let repo = TempRepo { dir };
         repo.must(&["init", "-q", "-b", "main"]);
         repo.apply_test_config();
@@ -54,11 +107,12 @@ impl TempRepo {
     /// above, and `patch.rs`'s `clone_of`, which used to hand-copy a subset of
     /// this list and drifted out of sync with it.
     ///
-    /// Everything here is set LOCALLY on purpose. `git()` below neutralizes the
-    /// host's global/system config for its OWN invocations, but the code under
-    /// test shells out to `git` itself with no such environment — so anything
-    /// that must hold for the code under test has to live in the repo, where it
-    /// outranks the host's global config.
+    /// Everything here is set LOCALLY on purpose: these are per-repo facts
+    /// (this repo's identity, this repo's gc policy), not properties of the
+    /// test run. Settings that must hold for EVERY git in the run — including
+    /// the ones the code under test spawns, and the ones inside submodule
+    /// clones no test ever gets to configure — belong in the run's own global
+    /// config instead; see `global_git_config`.
     pub fn apply_test_config(&self) {
         // CRITICAL: without this, a commit hangs forever on a GPG passphrase prompt.
         self.must(&["config", "commit.gpgsign", "false"]);
@@ -80,26 +134,6 @@ impl TempRepo {
         // the host's global config or GECOS data.
         self.must(&["config", "user.name", "GitCat Test"]);
         self.must(&["config", "user.email", "test@gitcat.example"]);
-        // Line endings, for the same reason as the identity above: Git for
-        // Windows installs `core.autocrlf=true` by default, which rewrites LF to
-        // CRLF on every checkout. A test writes "base\nline2\n", the code under
-        // test performs an operation that re-checkouts the file, and the
-        // assertion then compares against "base\r\nline2\r\n" — 58 failures on a
-        // Windows host, all of them the test being platform-naive rather than
-        // anything being wrong. Twelve more showed up as `is_clean()` returning
-        // false, the same cause wearing a different hat: git reports a file as
-        // modified when its line endings no longer match what the index expects.
-        //
-        // `core.eol` as well as autocrlf: autocrlf alone still leaves `eol` to
-        // decide the checkout form for paths marked `text` by a .gitattributes
-        // file, and some tests write one.
-        //
-        // This does NOT mean the app is untested against CRLF working trees —
-        // it means these assertions are about git plumbing, not about line
-        // endings, and a real user's autocrlf setting has no business deciding
-        // whether they pass.
-        self.must(&["config", "core.autocrlf", "false"]);
-        self.must(&["config", "core.eol", "lf"]);
         // Disable background auto-gc/maintenance: a test that creates MANY commits
         // rapidly (dashboard's `stays_cheap_…` runs a 300-commit loop) otherwise
         // intermittently trips `git gc --auto` repacking behind the next commit —
@@ -120,6 +154,7 @@ impl TempRepo {
         let dir = std::env::temp_dir()
             .join(format!("gitcat-test-{tag}-{}-{}-{}", std::process::id(), nanos, seq));
         std::fs::create_dir_all(&dir).expect("mkdir temp bare repo");
+        global_git_config();
         let repo = TempRepo { dir };
         repo.must(&["init", "-q", "--bare", "-b", "main"]);
         repo
@@ -133,23 +168,32 @@ impl TempRepo {
     /// Run `git -C <dir> <args…>` with reproducible author/committer identity
     /// and dates, capturing (exit-ok, trimmed stdout, trimmed stderr).
     /// Isolates every invocation from the HOST's own global/system git config
-    /// (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` point at `/dev/null`, git
-    /// >=2.32) — fixes a real blocking bug: `rerere.autoupdate`,
-    /// `rerere.enabled`, or any other setting a developer's or CI runner's own
-    /// dotfiles happen to set would otherwise silently leak into every test
-    /// repo and make assertions machine-dependent (verified: a personal
-    /// `~/.config/git/config` with `rerere.autoupdate=true` made an M5a rerere
-    /// replay assertion pass locally while it would fail on a clean runner
-    /// with no such config). Local (repo) config, set explicitly via `must`
-    /// calls below, is completely unaffected — only the global/system
-    /// fallback layers are neutralized.
+    /// (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`, git >=2.32) — fixes a real
+    /// blocking bug: `rerere.autoupdate`, `rerere.enabled`, or any other
+    /// setting a developer's or CI runner's own dotfiles happen to set would
+    /// otherwise silently leak into every test repo and make assertions
+    /// machine-dependent (verified: a personal `~/.config/git/config` with
+    /// `rerere.autoupdate=true` made an M5a rerere replay assertion pass
+    /// locally while it would fail on a clean runner with no such config).
+    /// Local (repo) config, set explicitly via `must` calls below, is
+    /// completely unaffected — only the global/system fallback layers are
+    /// replaced.
+    ///
+    /// These used to point at `/dev/null`. They now point at the run's own
+    /// config file (see `global_git_config`), which blocks the host's settings
+    /// just as well and additionally carries the line-ending keys — so a git
+    /// the fixture runs and a git the code under test runs see the SAME global
+    /// config, rather than one seeing none and the other seeing the host's.
+    /// Setting them here as well as process-wide is redundant by design: it
+    /// keeps the guarantee visible at the call site, where the comment above
+    /// explains why it matters.
     pub fn git(&self, args: &[&str]) -> (bool, String, String) {
         let out = Command::new("git")
             .arg("-C")
             .arg(&self.dir)
             .args(args)
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_CONFIG_GLOBAL", global_git_config())
+            .env("GIT_CONFIG_SYSTEM", global_git_config())
             .env("GIT_AUTHOR_NAME", "GitCat Test")
             .env("GIT_AUTHOR_EMAIL", "test@gitcat.example")
             .env("GIT_COMMITTER_NAME", "GitCat Test")

--- a/src-tauri/tests/common/mod.rs
+++ b/src-tauri/tests/common/mod.rs
@@ -45,13 +45,28 @@ impl TempRepo {
         std::fs::create_dir_all(&dir).expect("mkdir temp repo");
         let repo = TempRepo { dir };
         repo.must(&["init", "-q", "-b", "main"]);
+        repo.apply_test_config();
+        repo
+    }
+
+    /// The repo-LOCAL config every throwaway working-tree repo needs, in one
+    /// place because there is more than one way a test builds one: `init`
+    /// above, and `patch.rs`'s `clone_of`, which used to hand-copy a subset of
+    /// this list and drifted out of sync with it.
+    ///
+    /// Everything here is set LOCALLY on purpose. `git()` below neutralizes the
+    /// host's global/system config for its OWN invocations, but the code under
+    /// test shells out to `git` itself with no such environment — so anything
+    /// that must hold for the code under test has to live in the repo, where it
+    /// outranks the host's global config.
+    pub fn apply_test_config(&self) {
         // CRITICAL: without this, a commit hangs forever on a GPG passphrase prompt.
-        repo.must(&["config", "commit.gpgsign", "false"]);
+        self.must(&["config", "commit.gpgsign", "false"]);
         // Separate config key from commit.gpgsign — needed once a test creates
         // an annotated tag (`git tag -a`, e.g. tests/plumbing.rs); without this,
         // a host with tag signing defaulted on would hang the ENTIRE shared
         // test binary (this file is `mod common`'d by every tests/*.rs file).
-        repo.must(&["config", "tag.gpgsign", "false"]);
+        self.must(&["config", "tag.gpgsign", "false"]);
         // CRITICAL: repo-LOCAL identity, independent of any GIT_AUTHOR_*/GIT_COMMITTER_*
         // env vars (see `git()` below) or the machine's global/system git config. Code
         // under test (e.g. git_pick::cherry_pick_continue) shells out to git directly
@@ -63,16 +78,35 @@ impl TempRepo {
         // config sits above that fallback and below explicit env vars in git's identity
         // resolution, so this makes every throwaway repo self-sufficient regardless of
         // the host's global config or GECOS data.
-        repo.must(&["config", "user.name", "GitCat Test"]);
-        repo.must(&["config", "user.email", "test@gitcat.example"]);
+        self.must(&["config", "user.name", "GitCat Test"]);
+        self.must(&["config", "user.email", "test@gitcat.example"]);
+        // Line endings, for the same reason as the identity above: Git for
+        // Windows installs `core.autocrlf=true` by default, which rewrites LF to
+        // CRLF on every checkout. A test writes "base\nline2\n", the code under
+        // test performs an operation that re-checkouts the file, and the
+        // assertion then compares against "base\r\nline2\r\n" — 58 failures on a
+        // Windows host, all of them the test being platform-naive rather than
+        // anything being wrong. Twelve more showed up as `is_clean()` returning
+        // false, the same cause wearing a different hat: git reports a file as
+        // modified when its line endings no longer match what the index expects.
+        //
+        // `core.eol` as well as autocrlf: autocrlf alone still leaves `eol` to
+        // decide the checkout form for paths marked `text` by a .gitattributes
+        // file, and some tests write one.
+        //
+        // This does NOT mean the app is untested against CRLF working trees —
+        // it means these assertions are about git plumbing, not about line
+        // endings, and a real user's autocrlf setting has no business deciding
+        // whether they pass.
+        self.must(&["config", "core.autocrlf", "false"]);
+        self.must(&["config", "core.eol", "lf"]);
         // Disable background auto-gc/maintenance: a test that creates MANY commits
         // rapidly (dashboard's `stays_cheap_…` runs a 300-commit loop) otherwise
         // intermittently trips `git gc --auto` repacking behind the next commit —
         // observed as a flaky CI failure "error: bad tree object HEAD" mid-loop.
         // No test needs gc, so turn it off outright for every throwaway repo.
-        repo.must(&["config", "gc.auto", "0"]);
-        repo.must(&["config", "maintenance.auto", "false"]);
-        repo
+        self.must(&["config", "gc.auto", "0"]);
+        self.must(&["config", "maintenance.auto", "false"]);
     }
 
     /// A bare repo (no working tree) — stands in for a real remote in

--- a/src-tauri/tests/patch.rs
+++ b/src-tauri/tests/patch.rs
@@ -37,10 +37,11 @@ fn clone_of(src: &TempRepo, tag: &str) -> TempRepo {
         .expect("failed to spawn git clone");
     assert!(out.status.success(), "git clone failed: {}", String::from_utf8_lossy(&out.stderr));
     let repo = TempRepo { dir };
-    repo.must(&["config", "commit.gpgsign", "false"]);
-    repo.must(&["config", "tag.gpgsign", "false"]);
-    repo.must(&["config", "user.name", "GitCat Test"]);
-    repo.must(&["config", "user.email", "test@gitcat.example"]);
+    // A clone starts with none of the source repo's local config, so it needs
+    // the same treatment `TempRepo::init` gives. This used to be a hand-copied
+    // subset of that list, which is how it ended up missing the line-ending
+    // settings and failing three tests on Windows.
+    repo.apply_test_config();
     repo
 }
 

--- a/src-tauri/tests/submodule.rs
+++ b/src-tauri/tests/submodule.rs
@@ -1048,8 +1048,16 @@ fn submodule_sync_rewrites_git_config_url_after_gitmodules_is_hand_edited() {
     parent.must(&["commit", "-q", "-m", "point sub at a new home"]);
 
     // Confirm the split BEFORE syncing: .gitmodules moved, .git/config did not.
-    let gitmodules = parent.read(".gitmodules");
-    assert!(gitmodules.contains(&child_new.path()), "expected .gitmodules to record the new url");
+    //
+    // Read the value back through `git config` rather than substring-matching
+    // the file's text. `git config` ESCAPES backslashes when it writes a value,
+    // so a Windows path lands in the file doubled —
+    // `url = C:\\Users\\…\\child` — and a `contains(path)` on the raw text can
+    // never match. Reading it back also makes the assertion about the recorded
+    // VALUE rather than about the file's formatting, which is what this line
+    // was always trying to say.
+    let (_, gitmodules_url, _) = parent.git(&["config", "--get", "-f", ".gitmodules", "submodule.sub.url"]);
+    assert_eq!(gitmodules_url, child_new.path(), "expected .gitmodules to record the new url");
     let (_, url_still_stale, _) = parent.git(&["config", "--get", "submodule.sub.url"]);
     assert_eq!(url_still_stale, child.path(), ".git/config must still be stale before sync runs");
 
@@ -1284,8 +1292,22 @@ fn submodule_deinit_recovers_offline_via_init_and_update() {
 
     // Simulate the original source repo becoming permanently unreachable
     // (moved/deleted) — the offline-recovery property must not depend on it.
-    let moved_away = child.dir.with_file_name("submodule_deinit_offline_child_GONE");
+    //
+    // The destination name is derived from `child`'s own directory, which
+    // already carries pid + nanos + a counter. It used to be a FIXED string,
+    // which made this test poison itself: once the rename succeeded, nothing
+    // owned the result — `child`'s Drop removes `child.dir`, which no longer
+    // exists — so the renamed repo leaked into the temp dir, and every later
+    // run then hit `rename` onto an existing non-empty directory (ENOTEMPTY on
+    // unix, ERROR_DIR_NOT_EMPTY on Windows). CI never saw it because a fresh
+    // runner always starts with an empty temp dir.
+    let moved_away = child.dir.with_file_name(format!(
+        "{}-GONE",
+        child.dir.file_name().expect("temp repo dir has a final component").to_string_lossy()
+    ));
     std::fs::rename(&child.dir, &moved_away).expect("simulate the origin going away");
+    // Hand the renamed directory to a TempRepo purely so its Drop cleans up.
+    let _moved_away_owner = TempRepo { dir: moved_away.clone() };
 
     // init re-registers the (now-unreachable) url from .gitmodules — this
     // never dereferences the url, so it succeeds regardless.

--- a/src-tauri/tests/submodule.rs
+++ b/src-tauri/tests/submodule.rs
@@ -1752,6 +1752,11 @@ fn bug2_remove_refuses_when_a_nested_submodule_of_a_submodule_is_dirty() {
     assert!(!status_after.contains("D  sub"), "sub's gitlink must not have been staged for deletion: {status_after:?}");
 }
 
+// Unix-only: the precondition is a read-only DIRECTORY, which is what makes
+// the `.gitmodules` rewrite fail. Windows ignores the read-only attribute for
+// that purpose — there is no equivalent using file attributes, and an ACL deny
+// would be more machinery than this test is worth.
+#[cfg(unix)]
 #[test]
 fn bug3_remove_propagates_a_failed_gitmodules_fallback_instead_of_reporting_ok() {
     // BUG 3: the `.gitmodules` section-removal fallback (for when `git rm -f`
@@ -1804,6 +1809,9 @@ fn bug3_remove_propagates_a_failed_gitmodules_fallback_instead_of_reporting_ok()
     );
 }
 
+// Unix-only: needs a dangling symlink, which on Windows requires either
+// Developer Mode or elevation — not something a test run can assume.
+#[cfg(unix)]
 #[test]
 fn bug4_force_deinit_backs_up_a_dangling_symlinks_target_instead_of_refusing() {
     // BUG 4: the untracked-file backup loop called `fs::read(&src)`, which

--- a/src-tauri/tests/workdir.rs
+++ b/src-tauri/tests/workdir.rs
@@ -723,6 +723,12 @@ fn discard_file_reverses_an_unstaged_rename() {
 // reject only NUL/CR/LF, not every control character (e.g. a legitimate tab).
 // ---------------------------------------------------------------------------
 
+// Unix-only: a tab is not a legal character in a Windows filename, so the file
+// this test needs cannot be created there at all (`std::fs::write` fails with
+// ERROR_INVALID_NAME). The behaviour under test — that `stage_file` does not
+// reject a path git itself accepts — is unchanged on Windows; there is simply
+// no way to construct the input.
+#[cfg(unix)]
 #[test]
 fn stage_file_accepts_a_tab_containing_filename() {
     let repo = TempRepo::init("workdir_tab_filename");


### PR DESCRIPTION
Closes #102.

**Stacked on #98, #103, #104 and #105.** With this one in, the Rust suite is **697 passed / 0 failed on Windows** — from a suite that could not start at all.

## It is explained, and the app was never broken

The test read *nothing* from the PTY: not the echoed command, not cmd.exe's banner, not a prompt. Raising the wait to 20s changed nothing, which is what made it look mysterious.

ConPTY opens by asking the terminal where its cursor is — a Device Status Report, `ESC[6n` — and **blocks until something answers**. Reproduced outside the app with a standalone `portable-pty` program driven exactly like `open_pty_shell`:

| | bytes read | contents |
|---|---|---|
| no reply (what the test did) | **4** | the `ESC[6n` itself, and nothing further |
| replying `ESC[1;1R` first | **292** | banner, prompt, the echoed command, its output |

In the app, xterm.js answers that query automatically — which is exactly why the terminal drawer works on Windows. This test *is* the terminal, and answering is part of the job.

That also answers the question the issue said should be settled first ("does the built-in terminal actually work on Windows?"): yes, and no GUI run was needed to establish it — the mechanism accounts for both behaviours.

## Windows-only, deliberately

No unix pty asks this. And there the escape would not be consumed by anything: it would land in the line buffer and be prefixed to the command. That would *still* satisfy the assertion, because the shell's "not found" message quotes the command back — green while testing nothing. Worse than red.

Also switched the write to CRLF: cmd.exe submits a line on CR, and a unix pty translates CR to NL on input (ICRNL), so it reads the same on both.

## On the `filter_repo` four

Earlier PRs in this stack reported four failures as "not a repo problem — `git-filter-repo` is not installed locally, and CI installs it with pipx". Confirmed: installing it turned all four green with no code change. That is why the total here is 0 rather than 4.

## Verified

On Windows: `--lib` 256 passed / 0 failed; whole suite `cargo test -j 2 --no-fail-fast` 697 passed / 0 failed. Unaffected on unix — the reply is `#[cfg(windows)]`, and CR-submitted lines behave identically there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
