### PR TITLE
feat: right-click menus for file rows, folder rows and the open repository

### DIFF
--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -114,6 +114,10 @@ test("right-clicking a folder row opens its own menu, with no leading divider", 
   const folder = page.locator("#tree details.dir > summary").first();
   await expect(folder).toBeVisible();
 
+  // Captured BEFORE the right-click: reading it afterwards and comparing it
+  // to itself is an assertion that cannot fail.
+  const openBefore = await folder.evaluate((el) => (el.parentElement as HTMLDetailsElement).open);
+
   await folder.click({ button: "right" });
 
   const menu = page.locator(".ctxmenu");
@@ -128,10 +132,10 @@ test("right-clicking a folder row opens its own menu, with no leading divider", 
   // A right-click must not toggle the folder open or closed — <details>
   // reacts to a plain click, and the handler has to preventDefault so the
   // native menu does not appear either.
-  const openState = await folder.evaluate((el) => (el.parentElement as HTMLDetailsElement).open);
+  expect(await folder.evaluate((el) => (el.parentElement as HTMLDetailsElement).open)).toBe(openBefore);
+
   await page.keyboard.press("Escape");
   await expect(menu).toHaveCount(0);
-  expect(await folder.evaluate((el) => (el.parentElement as HTMLDetailsElement).open)).toBe(openState);
 
   expect(errors).toEqual([]);
 });

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -22,6 +22,9 @@ async function skipWizard(page: import("@playwright/test").Page) {
 // its first file row.
 async function fileRows(page: import("@playwright/test").Page) {
   await page.locator('#refLocal [data-branch="main"]').click();
+  // The commit's files live under the detail panel's "Changes" tab, which is
+  // not the one a commit opens on.
+  await page.locator("#detail .d-tabs .d-tab").nth(1).click();
   // #tree, not "#detail .file": the same file-tree snippet is rendered twice,
   // once inline and once inside the expanded-diff modal, so an unscoped
   // selector matches every row twice.
@@ -104,6 +107,7 @@ test("right-clicking a folder row opens its own menu, with no leading divider", 
   await page.goto("/");
   await skipWizard(page);
   await page.locator('#refLocal [data-branch="main"]').click();
+  await page.locator("#detail .d-tabs .d-tab").nth(1).click(); // the "Changes" tab
 
   // #tree for the same reason fileRows() scopes to it: the tree snippet is
   // rendered twice, inline and inside the expanded-diff modal.

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "@playwright/test";
+
+// Design mode (plain browser, no Tauri mock) — the same base `test` as
+// sidebar-jump-design/scroll-blit. The context menu itself is frontend-only:
+// building the item list, positioning it, and dismissing it never touch the
+// backend, so this covers the whole of what a browser can reach. The two
+// items that DO call Tauri (reveal / open in file manager) are unit-tested
+// against a mocked `commands` instead — there is no backend here to reveal
+// anything with.
+
+// In design mode the setup wizard opens at boot unconditionally and its scrim
+// swallows every click underneath (see sidebar-jump-design.spec.ts, which
+// documents the same dance). Escape is the wizard's own "Skip".
+async function skipWizard(page: import("@playwright/test").Page) {
+  const wizard = page.locator("#setupWizardScrim");
+  await expect(wizard).toHaveClass(/\bon\b/);
+  await page.keyboard.press("Escape");
+  await expect(wizard).not.toHaveClass(/\bon\b/);
+}
+
+// Select a commit so the detail panel's file tree is populated, then hand back
+// its first file row.
+async function fileRows(page: import("@playwright/test").Page) {
+  await page.locator('#refLocal [data-branch="main"]').click();
+  // #tree, not "#detail .file": the same file-tree snippet is rendered twice,
+  // once inline and once inside the expanded-diff modal, so an unscoped
+  // selector matches every row twice.
+  const rows = page.locator("#tree .file");
+  await expect(rows.first()).toBeVisible();
+  return rows;
+}
+
+test("right-clicking a commit's file row opens a menu, and dismisses like a popover", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto("/");
+  await skipWizard(page);
+  const file = (await fileRows(page)).first();
+
+  await file.click({ button: "right" });
+
+  const menu = page.locator(".ctxmenu");
+  await expect(menu).toBeVisible();
+  // Three of the row's own actions, a divider, then the three this menu adds.
+  await expect(menu.locator(".ctxmenu-item")).toHaveCount(6);
+  await expect(menu.locator(".ctxmenu-sep")).toHaveCount(1);
+
+  // The row it points at is the one that got selected, so the menu can never
+  // be read as acting on a different file than the highlighted one.
+  await expect(file).toHaveClass(/\bactive\b/);
+
+  // Escape dismisses, like every other popover in the app.
+  await page.keyboard.press("Escape");
+  await expect(menu).toHaveCount(0);
+
+  expect(errors).toEqual([]);
+});
+
+test("the menu stays on screen when the click is at the bottom edge", async ({ page }) => {
+  await page.goto("/");
+  await skipWizard(page);
+  const file = (await fileRows(page)).first();
+
+  // Right-click as low in the window as the row allows. A six-item menu
+  // opening downward from here would run past the fold, and the backdrop
+  // swallows scrolling, so the last items would be unreachable.
+  const box = (await file.boundingBox())!;
+  const viewport = page.viewportSize()!;
+  await file.click({ button: "right", position: { x: 5, y: Math.max(1, box.height - 1) } });
+
+  const menu = page.locator(".ctxmenu");
+  await expect(menu).toBeVisible();
+  const menuBox = (await menu.boundingBox())!;
+  expect(menuBox.y).toBeGreaterThanOrEqual(0);
+  expect(menuBox.y + menuBox.height).toBeLessThanOrEqual(viewport.height);
+  expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(viewport.width);
+});
+
+// Never two menus at once. The backdrop takes the dismissing click, so a
+// right-click elsewhere closes the open menu rather than opening a second one
+// — one extra click, and the same behaviour the Workdir menu already had.
+// What must never happen is the previous row's actions staying on screen.
+test("a right-click elsewhere dismisses the menu instead of stacking a second", async ({ page }) => {
+  await page.goto("/");
+  await skipWizard(page);
+  const files = await fileRows(page);
+  const count = await files.count();
+  test.skip(count < 2, "needs at least two demo files in the commit");
+
+  await files.nth(0).click({ button: "right" });
+  await expect(page.locator(".ctxmenu")).toHaveCount(1);
+  await page.locator(".ctxmenu-backdrop").click({ button: "right", position: { x: 5, y: 5 } });
+  await expect(page.locator(".ctxmenu")).toHaveCount(0);
+
+  await files.nth(1).click({ button: "right" });
+  await expect(page.locator(".ctxmenu")).toHaveCount(1);
+});
+
+// The bug this covers: folder rows were left without a handler when the file
+// rows got one, so right-clicking a folder in the tree did nothing at all.
+test("right-clicking a folder row opens its own menu, with no leading divider", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto("/");
+  await skipWizard(page);
+  await page.locator('#refLocal [data-branch="main"]').click();
+
+  // #tree for the same reason fileRows() scopes to it: the tree snippet is
+  // rendered twice, inline and inside the expanded-diff modal.
+  const folder = page.locator("#tree details.dir > summary").first();
+  await expect(folder).toBeVisible();
+
+  await folder.click({ button: "right" });
+
+  const menu = page.locator(".ctxmenu");
+  await expect(menu).toBeVisible();
+  // A folder row carries no icon buttons of its own, so the path trio is the
+  // whole menu — open, copy path, copy full path.
+  await expect(menu.locator(".ctxmenu-item")).toHaveCount(3);
+  // ...and being the only group, it must not draw a divider above its first
+  // item. The builder marks one; ContextMenu.svelte drops it at index 0.
+  await expect(menu.locator(".ctxmenu-sep")).toHaveCount(0);
+
+  // A right-click must not toggle the folder open or closed — <details>
+  // reacts to a plain click, and the handler has to preventDefault so the
+  // native menu does not appear either.
+  const openState = await folder.evaluate((el) => (el.parentElement as HTMLDetailsElement).open);
+  await page.keyboard.press("Escape");
+  await expect(menu).toHaveCount(0);
+  expect(await folder.evaluate((el) => (el.parentElement as HTMLDetailsElement).open)).toBe(openState);
+
+  expect(errors).toEqual([]);
+});

--- a/e2e/staging.spec.ts
+++ b/e2e/staging.spec.ts
@@ -179,7 +179,10 @@ for (const placement of ["right", "bottom"] as const) {
         .filter({ has: page.locator(".wd-path", { hasText: /^todo\.txt$/ }) });
       await expect(row).toBeVisible();
       await row.click({ button: "right" });
-      const menuItem = page.locator(".wd-rowmenu-item.danger");
+      // The shared context menu (islands/contextmenu), not Workdir's old
+      // hand-rolled popover — that markup is gone now that every file tree
+      // uses the one island.
+      const menuItem = page.locator(".ctxmenu-item.danger");
       await expect(menuItem).toBeVisible();
       await menuItem.click();
 

--- a/index.html
+++ b/index.html
@@ -1105,16 +1105,21 @@ button{font-family:inherit;font-size:inherit;color:inherit;cursor:pointer}
 /* Discard all — the danger-toned variant of a section action. */
 .wd-discard-all{color:var(--danger);border-color:color-mix(in srgb,var(--danger) 45%,var(--border))}
 .wd-discard-all:hover:not([disabled]){background:color-mix(in srgb,var(--danger) 12%,transparent)}
-/* Per-file right-click menu (Workdir.svelte). Fixed-position popover + a
-   full-screen transparent backdrop that catches the dismissing click. */
-.wd-rowmenu-backdrop{position:fixed;inset:0;z-index:60}
-.wd-rowmenu{position:fixed;z-index:61;min-width:150px;background:var(--panel);border:1px solid var(--border);
+/* Shared right-click menu (src/islands/contextmenu). Fixed-position popover +
+   a full-screen transparent backdrop that catches the dismissing click. Was
+   .wd-rowmenu*, Workdir's own; generalized when the commit file list and the
+   repo chip grew menus too — see contextmenu.svelte.ts's header. The popover
+   is positioned by the component, which flips it away from the viewport edge
+   rather than letting a long menu run off the bottom. */
+.ctxmenu-backdrop{position:fixed;inset:0;z-index:60}
+.ctxmenu{position:fixed;z-index:61;min-width:150px;background:var(--panel);border:1px solid var(--border);
   border-radius:var(--r-panel);box-shadow:0 10px 30px rgba(0,0,0,.35);padding:4px;display:flex;flex-direction:column}
-.wd-rowmenu-item{text-align:left;background:transparent;border:0;border-radius:6px;padding:7px 10px;font-size:12.5px;color:var(--text);cursor:pointer}
-.wd-rowmenu-item:hover:not([disabled]){background:color-mix(in srgb,var(--text) 8%,transparent)}
-.wd-rowmenu-item.danger{color:var(--danger)}
-.wd-rowmenu-item.danger:hover:not([disabled]){background:color-mix(in srgb,var(--danger) 12%,transparent)}
-.wd-rowmenu-item[disabled]{opacity:.5;cursor:default}
+.ctxmenu-item{text-align:left;background:transparent;border:0;border-radius:6px;padding:7px 10px;font-size:12.5px;color:var(--text);cursor:pointer;white-space:nowrap}
+.ctxmenu-item:hover:not([disabled]){background:color-mix(in srgb,var(--text) 8%,transparent)}
+.ctxmenu-item.danger{color:var(--danger)}
+.ctxmenu-item.danger:hover:not([disabled]){background:color-mix(in srgb,var(--danger) 12%,transparent)}
+.ctxmenu-item[disabled]{opacity:.5;cursor:default}
+.ctxmenu-sep{height:1px;margin:4px 6px;background:var(--border)}
 .wd-files{display:flex;flex-direction:column;gap:1px}
 .wd-file{display:flex;align-items:center;gap:7px;padding:4px 5px;border-radius:6px;cursor:pointer;font-size:12px}
 .wd-file:hover{background:var(--elevated)}

--- a/src-tauri/src/file_manager.rs
+++ b/src-tauri/src/file_manager.rs
@@ -1,0 +1,232 @@
+//! "Show in <file manager>" / "Open in <file manager>" — the two context-menu
+//! actions that hand a path to the desktop's own file browser (Explorer,
+//! Finder, or whatever the Linux session provides).
+//!
+//! These go through Rust even though `@tauri-apps/plugin-opener` ships a JS
+//! binding for both, and `revealItemInDir` is already allowed by this app's
+//! `opener:default` capability. The OPEN half is the reason: it needs
+//! `allow-open-path`, and that permission's scope check (`scope.rs`'s
+//! `is_path_allowed`) ends in `self.allowed.iter().any(...)`, which is false
+//! for an empty allow list — so the capability would also have to carry one,
+//! and the only list broad enough for "whichever repo the user has open" is
+//! `**`. That grants the webview the right to ask the OS to open ANY path
+//! with its default application, and this app runs third-party plugin code in
+//! that webview (see `plugin_exec.rs`). Keeping both actions here puts them
+//! behind `trust::open_repo` instead — the same gate `terminal.rs` uses for
+//! the considerably more powerful shell it spawns.
+//!
+//! Both commands take the repo path and a repo-RELATIVE path (the form every
+//! file list in the app already holds, and the form git itself prints), empty
+//! for the repo itself. Joining them here keeps the join and its containment
+//! check in one testable place rather than repeated in each caller's Svelte.
+
+use std::path::{Component, Path, PathBuf};
+
+use tauri::{AppHandle, Wry};
+use tauri_plugin_opener::OpenerExt;
+
+use crate::i18n_err::ierrp;
+
+/// A path in the form the desktop shell accepts, not merely the form the
+/// Win32 file APIs accept.
+///
+/// The two plugin calls below disagree about the Windows extended-length
+/// `\\?\C:\…` form: `reveal_item_in_dir` puts its argument through
+/// `dunce::simplified`, which drops the prefix, while `open_path` only stats
+/// the path (which succeeds — that is exactly what the prefix is for) and
+/// then hands it to `ShellExecute`, which does not understand it. Same input,
+/// one works and one does not.
+///
+/// Nothing upstream should hand us that form today: `repo_registry::normalize`
+/// and the `gitcat .` argument classifier both strip it (see
+/// `windows::strip_windows_verbatim_prefix`, and #42 for what happens when a
+/// path in this form reaches something that cannot take it). So this is the
+/// invariant held where it is relied on, rather than a fix for a path anyone
+/// has seen arrive. A no-op for every other input, on every platform.
+fn shell_path(repo: &str) -> String {
+    crate::windows::strip_windows_verbatim_prefix(repo.to_string())
+}
+
+/// Join a repo-relative path onto its repo, refusing anything that would
+/// escape.
+///
+/// Callers pass paths that came from this app's own file lists, so a
+/// traversal here would be a bug rather than an attack — but the check is two
+/// lines and the failure it prevents (revealing, or opening, a file outside
+/// the repo the user trusted) is the kind that is embarrassing to explain
+/// afterwards.
+///
+/// Rejects an absolute `relative`, any `..`, and a Windows drive prefix.
+/// Plain `.` components are dropped rather than refused: they are harmless
+/// and `Path::components` produces them for a leading `./`.
+///
+/// The repo base goes through [`shell_path`] first, so the joined result is a
+/// form the shell will accept.
+fn resolve_in_repo(repo: &str, relative: &str) -> Result<PathBuf, String> {
+    let rel = Path::new(relative);
+    if rel.is_absolute() {
+        return Err(format!("refusing an absolute path where a repo-relative one was expected: {relative}"));
+    }
+    let mut out = PathBuf::from(shell_path(repo));
+    for c in rel.components() {
+        match c {
+            Component::Normal(part) => out.push(part),
+            Component::CurDir => {}
+            // ParentDir, RootDir and Prefix all mean this is not the
+            // repo-relative path it claimed to be.
+            _ => return Err(format!("refusing a path that escapes the repository: {relative}")),
+        }
+    }
+    Ok(out)
+}
+
+/// JS: `commands.revealPathInFileManager(repo, relative)` — a file row's
+/// "Show in <file manager>": opens the containing folder with the file
+/// selected. `async` + `run_blocking` because the trust gate is a git2
+/// `Repository::open`, exactly as in `terminal_spawn`.
+#[tauri::command]
+#[specta::specta]
+pub async fn reveal_path_in_file_manager(app: AppHandle<Wry>, repo: String, relative: String) -> Result<(), String> {
+    let target = crate::blocking::run_blocking(move || {
+        if let Err(e) = crate::trust::open_repo(&repo) {
+            return Err(ierrp("err_misc.cannot_open_repo_cap", &[("detail", e.message())]));
+        }
+        resolve_in_repo(&repo, &relative)
+    })
+    .await?;
+    app.opener().reveal_item_in_dir(target).map_err(|e| e.to_string())
+}
+
+/// JS: `commands.openDirInFileManager(repo, relative)` — the topbar repo
+/// chip's and a folder row's "Open in <file manager>".
+///
+/// `open_path`, not the reveal above: revealing a directory opens its PARENT
+/// with the directory merely selected, and a folder is a thing you want to be
+/// INSIDE. That distinction is the whole reason the two labels use different
+/// verbs (see `legacy/platform.ts`).
+///
+/// An empty `relative` means the repo itself, which is what the repo chip
+/// passes. `resolve_in_repo` already drops the nothing-at-all case, so the
+/// chip and a folder row go through one command rather than two that would
+/// have to be kept in step.
+#[tauri::command]
+#[specta::specta]
+pub async fn open_dir_in_file_manager(app: AppHandle<Wry>, repo: String, relative: String) -> Result<(), String> {
+    let path = crate::blocking::run_blocking(move || {
+        if let Err(e) = crate::trust::open_repo(&repo) {
+            return Err(ierrp("err_misc.cannot_open_repo_cap", &[("detail", e.message())]));
+        }
+        resolve_in_repo(&repo, &relative)
+    })
+    .await?;
+    // `open_path` takes a String where `reveal_item_in_dir` takes a Path, so
+    // this one has to come back out. Nothing can be lost: both halves arrived
+    // as Rust `String`s and are therefore already UTF-8, and the join only
+    // concatenates components of them.
+    app.opener()
+        .open_path(path.to_string_lossy().into_owned(), None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn joins_a_repo_relative_path_onto_its_repo() {
+        let out = resolve_in_repo("/home/me/proj", "src/main.rs").expect("a plain relative path joins");
+        assert_eq!(out, Path::new("/home/me/proj").join("src").join("main.rs"));
+    }
+
+    // The repo chip's own "Open in <file manager>" passes an empty relative,
+    // so one command serves both it and a folder row. An empty path has no
+    // components at all, which is why this needs no special case above — but
+    // it is the whole reason the two callers can share, so it is pinned.
+    #[test]
+    fn an_empty_relative_means_the_repo_itself() {
+        assert_eq!(resolve_in_repo("/home/me/proj", "").expect("empty joins"), Path::new("/home/me/proj"));
+        assert_eq!(resolve_in_repo("/home/me/proj", ".").expect("a bare dot joins"), Path::new("/home/me/proj"));
+    }
+
+    // A directory is an ordinary relative path — nothing about the join cares
+    // that the target is a folder, and a trailing slash (which a tree node's
+    // path never has, but a caller could) must not produce a stray component.
+    #[test]
+    fn joins_a_directory_the_same_way() {
+        assert_eq!(resolve_in_repo("/repo", "src/islands").expect("joins"), Path::new("/repo").join("src").join("islands"));
+        assert_eq!(resolve_in_repo("/repo", "src/islands/").expect("joins"), Path::new("/repo").join("src").join("islands"));
+    }
+
+    // `Path::components` yields CurDir for a leading "./", and git itself
+    // never prints one — but a caller trimming a prefix can produce it, and
+    // refusing would be a pointless failure.
+    fn dropped(p: &str) -> PathBuf {
+        resolve_in_repo("/repo", p).expect("should join")
+    }
+    #[test]
+    fn a_leading_dot_segment_is_dropped_rather_than_refused() {
+        assert_eq!(dropped("./src/main.rs"), Path::new("/repo").join("src").join("main.rs"));
+    }
+
+    // The point of the check: these are the shapes that would put the
+    // revealed item outside the repo the user actually trusted.
+    #[test]
+    fn refuses_anything_that_leaves_the_repo() {
+        assert!(resolve_in_repo("/home/me/proj", "../secrets").is_err());
+        assert!(resolve_in_repo("/home/me/proj", "src/../../secrets").is_err());
+        assert!(resolve_in_repo("/home/me/proj", "/etc/passwd").is_err());
+    }
+
+    // A drive-qualified path is refused where it can actually denote a drive:
+    // on Windows `C:\Windows\System32` is absolute, so the guard above rejects
+    // it before any component is looked at.
+    //
+    // Off Windows the same string is not a path at all. Backslash is an
+    // ordinary filename character there, so it arrives as ONE Normal
+    // component — `Component::Prefix` is Windows-only and never appears — and
+    // git can legitimately track a file named exactly that. Refusing it would
+    // be a false positive on a real file, and there is nothing to refuse it
+    // for: the join still lands inside the repo, which is the property this
+    // function exists to guarantee. So that is what gets asserted instead.
+    //
+    // (An earlier version of this asserted Err on both platforms, on the
+    // reasoning that a drive letter becomes a Prefix component off Windows.
+    // It does not, and Linux CI said so: `Ok("C:\\repo/C:\\Windows\\System32")`.)
+    #[test]
+    fn a_drive_qualified_path_is_refused_on_windows_and_contained_elsewhere() {
+        let out = resolve_in_repo(r"C:\repo", r"C:\Windows\System32");
+        #[cfg(windows)]
+        assert!(out.is_err(), "a drive-qualified path is absolute on Windows: {out:?}");
+        #[cfg(not(windows))]
+        assert_eq!(
+            out.expect("off Windows this is an ordinary, if odd, filename"),
+            Path::new(r"C:\repo").join(r"C:\Windows\System32"),
+            "it must still land inside the repo"
+        );
+    }
+
+    // A repo stored in the Windows extended-length form joins into an
+    // ordinary path, so `open_path`'s ShellExecute gets something it can use
+    // and the two commands agree with each other. Asserted on every platform:
+    // it is pure string work, and the rule should not be able to regress on
+    // the platform CI does not run it on.
+    #[test]
+    fn an_extended_length_repo_path_is_reduced_to_the_ordinary_form() {
+        assert_eq!(shell_path(r"\\?\C:\Users\me\proj"), r"C:\Users\me\proj");
+        assert_eq!(shell_path(r"\\?\UNC\wsl.localhost\Ubuntu\home\me\proj"), r"\\wsl.localhost\Ubuntu\home\me\proj");
+        assert_eq!(shell_path("/home/me/proj"), "/home/me/proj");
+
+        let out = resolve_in_repo(r"\\?\C:\repo", "src/main.rs").expect("should join");
+        assert_eq!(out, Path::new(r"C:\repo").join("src").join("main.rs"));
+    }
+
+    // Spaces, dots and non-ASCII are ordinary in real filenames and must not
+    // be confused with traversal.
+    #[test]
+    fn ordinary_awkward_filenames_still_join() {
+        assert!(resolve_in_repo("/repo", "a dir/two words.txt").is_ok());
+        assert!(resolve_in_repo("/repo", "docs/.gitkeep").is_ok());
+        assert!(resolve_in_repo("/repo", "문서/설계.md").is_ok());
+        assert!(resolve_in_repo("/repo", "..hidden-but-not-traversal").is_ok());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub mod preview; // #37: raw image/PDF blob bytes for a visual before/after diff
 pub mod procutil; // suppresses the console window Windows flashes open per subprocess spawn
 pub mod reflog; // M4: reflog rescue (read HEAD reflog + restore to a historical entry)
 pub mod repo_files; // backlog #14 (final item): .gitignore/.mailmap in-app editors — allow-listed repo-root file read/write
+pub mod file_manager; // row/repo context menus: hand a path to the desktop file browser, trust-gated (see its module doc)
 pub mod repo_registry; // backlog #11: app-level tracked-repos JSON persistence
 pub mod repo_summary; // Repository Summary: git-log-derived churn/contributor/activity/problem-area diagnostics
 pub mod rerere; // M5a: git-rerere status/toggle panel
@@ -347,6 +348,11 @@ fn specta_builder() -> Builder<tauri::Wry> {
         terminal::terminal_write,
         terminal::terminal_resize,
         terminal::terminal_kill,
+        // Right-click menus: reveal a file, or open the repo, in the
+        // desktop file browser. Rust-side so neither needs a blanket
+        // opener scope in the webview — see file_manager.rs's module doc.
+        file_manager::reveal_path_in_file_manager,
+        file_manager::open_dir_in_file_manager,
         // Multi-window: the Dashboard's "Open in New Window" row action (the
         // generic "New Window" menu item is handled entirely in Rust, see
         // menu.rs's own handle_event — no command round trip for that path).

--- a/src/i18n/locales/en/common.ts
+++ b/src/i18n/locales/en/common.ts
@@ -11,4 +11,23 @@ export default {
   // says which list it resizes. Double-click is otherwise undiscoverable.
   splitter_tip: "Drag to resize — double-click to reset",
   install: "Install",
+
+  // Row / repo context menus (Detail, Workdir, the topbar repo chip).
+  //
+  // The reveal_* and open_dir_* families are the ONE place this app's copy
+  // varies by platform — see legacy/platform.ts for why a proper noun earns
+  // that when a ⌘ glyph does not. Translators: keep whatever the OS itself
+  // is called in your language (Finder ships under a localized name in some
+  // locales), and keep the two verbs distinct — reveal_* opens the
+  // containing folder with the file selected, open_dir_* lands you inside
+  // the folder.
+  reveal_windows: "Show in File Explorer",
+  reveal_macos: "Reveal in Finder",
+  reveal_linux: "Show in file manager",
+  open_dir_windows: "Open in File Explorer",
+  open_dir_macos: "Open in Finder",
+  open_dir_linux: "Open in file manager",
+  // Repo-relative (what git itself prints) vs absolute.
+  copy_path: "Copy path",
+  copy_full_path: "Copy full path",
 };

--- a/src/i18n/locales/en/common.ts
+++ b/src/i18n/locales/en/common.ts
@@ -9,6 +9,10 @@ export default {
   // Tooltip on the divider between two panes (islands/detailpanel/Splitter).
   // Names the gesture, not the panes — the divider's accessible name already
   // says which list it resizes. Double-click is otherwise undiscoverable.
+  // Shown when the OS file manager refuses the path — most often a file
+  // from an older commit that is no longer on disk.
+  warn_reveal_failed: "Couldn't show that in the file manager — {reason}",
+  warn_open_dir_failed: "Couldn't open that folder — {reason}",
   splitter_tip: "Drag to resize — double-click to reset",
   install: "Install",
 

--- a/src/i18n/locales/ko/common.ts
+++ b/src/i18n/locales/ko/common.ts
@@ -9,6 +9,10 @@ export default {
   // 두 창 사이 분할선의 툴팁이에요(islands/detailpanel/Splitter). 어떤 목록을
   // 조절하는지는 접근성 이름이 이미 말해주니, 여기선 동작만 알려줘요.
   // 두 번 클릭은 알려주지 않으면 알 수가 없는 동작이라 넣었어요.
+  // OS 파일 관리자가 경로를 거부했을 때 나와요. 대개 예전 커밋의
+  // 파일이라 지금 디스크에 없는 경우예요.
+  warn_reveal_failed: "파일 관리자에서 못 열었어요 — {reason}",
+  warn_open_dir_failed: "그 폴더를 못 열었어요 — {reason}",
   splitter_tip: "끌어서 크기 조절 — 두 번 클릭하면 원래대로",
   install: "설치",
 

--- a/src/i18n/locales/ko/common.ts
+++ b/src/i18n/locales/ko/common.ts
@@ -11,4 +11,17 @@ export default {
   // 두 번 클릭은 알려주지 않으면 알 수가 없는 동작이라 넣었어요.
   splitter_tip: "끌어서 크기 조절 — 두 번 클릭하면 원래대로",
   install: "설치",
+
+  // 행 / 저장소 우클릭 메뉴(Detail, Workdir, 상단바 저장소 이름).
+  // reveal_*는 파일이 든 폴더를 열고 그 파일을 선택해요. open_dir_*는 그
+  // 폴더 안으로 바로 들어가요 — 두 동사를 섞지 말아주세요.
+  reveal_windows: "파일 탐색기에서 보기",
+  reveal_macos: "Finder에서 보기",
+  reveal_linux: "파일 관리자에서 보기",
+  open_dir_windows: "파일 탐색기에서 열기",
+  open_dir_macos: "Finder에서 열기",
+  open_dir_linux: "파일 관리자에서 열기",
+  // 저장소 기준 상대 경로(git이 그대로 쓰는 형태)와 절대 경로.
+  copy_path: "경로 복사",
+  copy_full_path: "전체 경로 복사",
 };

--- a/src/i18n/locales/zh/common.ts
+++ b/src/i18n/locales/zh/common.ts
@@ -9,4 +9,16 @@ export default {
   // 两个面板之间分隔条的提示（islands/detailpanel/Splitter）。
   splitter_tip: "拖动调整大小 — 双击复原",
   install: "安装",
+
+  // 行 / 仓库右键菜单（Detail、Workdir、顶栏仓库名）。reveal_* 打开所在文件夹
+  // 并选中该文件，open_dir_* 直接进入该文件夹 —— 两个动词要保持区分。
+  reveal_windows: "在文件资源管理器中显示",
+  reveal_macos: "在访达中显示",
+  reveal_linux: "在文件管理器中显示",
+  open_dir_windows: "在文件资源管理器中打开",
+  open_dir_macos: "在访达中打开",
+  open_dir_linux: "在文件管理器中打开",
+  // 相对仓库根目录（git 自己打印的形式）与绝对路径。
+  copy_path: "复制路径",
+  copy_full_path: "复制完整路径",
 };

--- a/src/i18n/locales/zh/common.ts
+++ b/src/i18n/locales/zh/common.ts
@@ -7,6 +7,8 @@ export default {
   remove: "移除",
   loading: "加载中…",
   // 两个面板之间分隔条的提示（islands/detailpanel/Splitter）。
+  warn_reveal_failed: "无法在文件管理器中显示 — {reason}",
+  warn_open_dir_failed: "无法打开该文件夹 — {reason}",
   splitter_tip: "拖动调整大小 — 双击复原",
   install: "安装",
 

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -3251,6 +3251,42 @@ async terminalKill(id: string) : Promise<Result<null, string>> {
 }
 },
 /**
+ * JS: `commands.revealPathInFileManager(repo, relative)` — a file row's
+ * "Show in <file manager>": opens the containing folder with the file
+ * selected. `async` + `run_blocking` because the trust gate is a git2
+ * `Repository::open`, exactly as in `terminal_spawn`.
+ */
+async revealPathInFileManager(repo: string, relative: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("reveal_path_in_file_manager", { repo, relative }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * JS: `commands.openDirInFileManager(repo, relative)` — the topbar repo
+ * chip's and a folder row's "Open in <file manager>".
+ * 
+ * `open_path`, not the reveal above: revealing a directory opens its PARENT
+ * with the directory merely selected, and a folder is a thing you want to be
+ * INSIDE. That distinction is the whole reason the two labels use different
+ * verbs (see `legacy/platform.ts`).
+ * 
+ * An empty `relative` means the repo itself, which is what the repo chip
+ * passes. `resolve_in_repo` already drops the nothing-at-all case, so the
+ * chip and a folder row go through one command rather than two that would
+ * have to be kept in step.
+ */
+async openDirInFileManager(repo: string, relative: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_dir_in_file_manager", { repo, relative }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * JS: `commands.openRepoInNewWindow(path)` — the Dashboard's "Open in New
  * Window" row action (see `src/islands/dashboard/dashboard.svelte.ts`'s
  * `openRepositoryInNewWindow`). Deliberately synchronous/non-async:

--- a/src/islands/contextmenu/ContextMenu.svelte
+++ b/src/islands/contextmenu/ContextMenu.svelte
@@ -1,0 +1,86 @@
+<!--
+  The shared right-click menu (see contextmenu.svelte.ts for why one exists).
+
+  Mounted once on <body> from src/main.ts, like every other overlay island —
+  each surface calls contextMenuCtrl.open(items, x, y) from its own
+  oncontextmenu handler instead of rendering a menu of its own.
+-->
+<script lang="ts">
+  import { contextMenuCtrl } from "./contextmenu.svelte.ts";
+
+  // Measured, not guessed: the item count varies per surface (three on the
+  // repo chip, seven on a commit's file row), so a fixed height estimate
+  // would clamp the short menus too early and the long ones too late.
+  let menuW = $state(0);
+  let menuH = $state(0);
+
+  // Keep the menu fully on screen. A right-click near the bottom of the
+  // window — which is exactly where the commit file list lives — would
+  // otherwise open a menu whose last items are below the fold and
+  // unreachable, since the backdrop swallows any scroll.
+  //
+  // Flip rather than merely clamp: at the bottom edge, sliding the menu up
+  // by its own height puts it ABOVE the cursor (the direction the pointer
+  // came from), whereas clamping would leave it under the cursor covering
+  // the row that was just right-clicked.
+  const PAD = 6;
+  const pos = $derived.by(() => {
+    const m = contextMenuCtrl.menu;
+    if (!m) return { left: 0, top: 0 };
+    // Before the first measurement both are 0, so this is the identity —
+    // the menu paints at the click point for one frame, then settles.
+    const vw = typeof window === "undefined" ? 0 : window.innerWidth;
+    const vh = typeof window === "undefined" ? 0 : window.innerHeight;
+    const left = vw && m.x + menuW + PAD > vw ? Math.max(PAD, m.x - menuW) : m.x;
+    const top = vh && m.y + menuH + PAD > vh ? Math.max(PAD, m.y - menuH) : m.y;
+    return { left, top };
+  });
+</script>
+
+<!--
+  Dismissal. A context menu has to go away on anything that means "I'm done
+  looking at this": Escape, a scroll (the row it points at would slide out
+  from under it), and a window resize (the clamp above is computed against
+  one viewport size). The backdrop below covers plain clicks, including a
+  right-click, which otherwise would open the browser's own menu on top.
+-->
+<svelte:window
+  onkeydown={(e) => {
+    if (e.key === "Escape" && contextMenuCtrl.menu) contextMenuCtrl.close();
+  }}
+  onscroll={() => contextMenuCtrl.close()}
+  onresize={() => contextMenuCtrl.close()}
+/>
+
+{#if contextMenuCtrl.menu}
+  <div
+    class="ctxmenu-backdrop"
+    role="presentation"
+    onclick={() => contextMenuCtrl.close()}
+    oncontextmenu={(e) => {
+      e.preventDefault();
+      contextMenuCtrl.close();
+    }}
+  ></div>
+  <div class="ctxmenu" style="left:{pos.left}px; top:{pos.top}px" bind:clientWidth={menuW} bind:clientHeight={menuH} role="menu" tabindex="-1">
+    {#each contextMenuCtrl.menu.items as item, i (item.id)}
+      <!--
+        A divider before the FIRST item is never meaningful — it separates the
+        list from nothing. This matters because the shared item builders
+        (fileitems/diritems) mark their group break on their own first entry,
+        which is right when a surface puts its own actions above them and a
+        stray top border when it does not (Detail's folder rows).
+      -->
+      {#if item.separatorBefore && i > 0}
+        <div class="ctxmenu-sep" role="separator"></div>
+      {/if}
+      <button
+        class="ctxmenu-item"
+        class:danger={item.danger}
+        role="menuitem"
+        disabled={item.disabled}
+        onclick={() => contextMenuCtrl.run(item)}>{item.label}</button
+      >
+    {/each}
+  </div>
+{/if}

--- a/src/islands/contextmenu/contextmenu.svelte.test.ts
+++ b/src/islands/contextmenu/contextmenu.svelte.test.ts
@@ -1,0 +1,77 @@
+// Tests for the shared right-click menu's controller.
+//
+// The controller owns only "which items, and where" — rendering, viewport
+// clamping and dismissal live in ContextMenu.svelte. Everything asserted
+// here is what a caller can get wrong: running a disabled item, running an
+// item after the menu was dismissed, or leaving one menu's items on screen
+// when another opens.
+import { describe, expect, it, vi } from "vitest";
+
+import { contextMenuCtrl } from "./contextmenu.svelte.ts";
+
+function item(label: string, extra: Record<string, unknown> = {}) {
+  return { id: label, label, run: vi.fn(), ...extra };
+}
+
+describe("contextMenuCtrl", () => {
+  it("starts closed", () => {
+    contextMenuCtrl.close();
+    expect(contextMenuCtrl.menu).toBeNull();
+  });
+
+  it("opens with the items and the click point", () => {
+    contextMenuCtrl.open([item("Blame")], 120, 340);
+    expect(contextMenuCtrl.menu?.items).toHaveLength(1);
+    expect(contextMenuCtrl.menu?.x).toBe(120);
+    expect(contextMenuCtrl.menu?.y).toBe(340);
+    contextMenuCtrl.close();
+  });
+
+  // Right-clicking a second row while the first row's menu is still up must
+  // REPLACE it. Appending would leave the previous row's actions on screen
+  // pointing at a file the user is no longer looking at.
+  it("a second open replaces the first menu rather than stacking", () => {
+    contextMenuCtrl.open([item("first")], 0, 0);
+    contextMenuCtrl.open([item("second"), item("third")], 10, 10);
+    expect(contextMenuCtrl.menu?.items.map((i) => i.label)).toEqual(["second", "third"]);
+    contextMenuCtrl.close();
+  });
+
+  // The menu has to be gone BEFORE the action runs: several of these open a
+  // dialog or a confirm scrim, and a still-mounted backdrop would swallow
+  // the first click in it.
+  it("closes before running, so an action that opens a dialog is not dismissed by its own backdrop", () => {
+    const seen: Array<unknown> = [];
+    const it0 = { id: "open", label: "open something", run: () => seen.push(contextMenuCtrl.menu) };
+    contextMenuCtrl.open([it0], 0, 0);
+    contextMenuCtrl.run(it0);
+    expect(seen).toEqual([null]);
+    expect(contextMenuCtrl.menu).toBeNull();
+  });
+
+  it("a disabled item does nothing at all, and leaves the menu open", () => {
+    const disabled = item("Show in file manager", { disabled: true });
+    contextMenuCtrl.open([disabled], 0, 0);
+    contextMenuCtrl.run(disabled);
+    expect(disabled.run).not.toHaveBeenCalled();
+    expect(contextMenuCtrl.menu).not.toBeNull();
+    contextMenuCtrl.close();
+  });
+
+  // close() is wired to a backdrop click, Escape, and a window scroll, so it
+  // lands on an already-closed menu routinely.
+  it("closing twice is harmless", () => {
+    contextMenuCtrl.open([item("x")], 0, 0);
+    contextMenuCtrl.close();
+    contextMenuCtrl.close();
+    expect(contextMenuCtrl.menu).toBeNull();
+  });
+
+  // A right-click that produces no applicable action should not flash an
+  // empty box — the caller can pass its list straight through without
+  // filtering for emptiness first.
+  it("opening with no items is a no-op", () => {
+    contextMenuCtrl.open([], 5, 5);
+    expect(contextMenuCtrl.menu).toBeNull();
+  });
+});

--- a/src/islands/contextmenu/contextmenu.svelte.ts
+++ b/src/islands/contextmenu/contextmenu.svelte.ts
@@ -1,0 +1,72 @@
+// Shared right-click menu — one component + one controller, used by every
+// surface that needs a context menu.
+//
+// Why shared rather than another hand-rolled one: Workdir already grew its
+// own (a backdrop div plus an absolutely positioned div), Sidebar grew a
+// second, and this change adds two more surfaces. A fourth copy would mean
+// four places to fix the next positioning or dismissal bug in. Sidebar's own
+// menus are deliberately NOT migrated here — they are unrelated to this
+// change and rewriting them would put working code at risk for tidiness.
+//
+// The controller owns only what a caller can get wrong; rendering, viewport
+// clamping and dismissal are ContextMenu.svelte's.
+
+export type ContextMenuItem = {
+  /// Stable, translation-independent identity: the `{#each}` key, and what
+  /// tests address an item by. Keying on the label instead would collide the
+  /// moment two items translate to the same string, and would make every
+  /// assertion depend on the active locale.
+  id: string;
+  /// Already translated by the caller — this module never calls `t()`, so it
+  /// stays free of any i18n or app dependency.
+  label: string;
+  run: () => void;
+  /// Renders in the danger colour (destructive actions, e.g. Discard).
+  danger?: boolean;
+  /// Shown but unrunnable — used for an action that does not apply to THIS
+  /// row (revealing a file the commit deleted, which is not on disk). Kept
+  /// visible rather than hidden so the menu's shape doesn't shift between
+  /// rows, which is what makes a menu hard to build muscle memory for.
+  disabled?: boolean;
+  /// Draws a divider above this item. Groups the actions a surface already
+  /// had from the ones this change adds.
+  separatorBefore?: boolean;
+};
+
+type OpenMenu = { items: ContextMenuItem[]; x: number; y: number };
+
+class ContextMenuState {
+  menu = $state<OpenMenu | null>(null);
+
+  /**
+   * Show `items` at the click point. A second call replaces whatever was
+   * open — right-clicking another row must not leave the previous row's
+   * actions on screen, pointing at a file the user has moved away from.
+   *
+   * An empty list is a no-op rather than an empty box, so callers can build
+   * their list conditionally and pass it straight through.
+   */
+  open(items: ContextMenuItem[], x: number, y: number): void {
+    if (!items.length) return;
+    this.menu = { items, x, y };
+  }
+
+  close(): void {
+    this.menu = null;
+  }
+
+  /**
+   * Run an item's action.
+   *
+   * Closes FIRST: several of these actions open a dialog or a confirm
+   * scrim, and this menu's own backdrop would otherwise still be mounted to
+   * swallow the first click in whatever just opened.
+   */
+  run(item: ContextMenuItem): void {
+    if (item.disabled) return;
+    this.close();
+    item.run();
+  }
+}
+
+export const contextMenuCtrl = new ContextMenuState();

--- a/src/islands/contextmenu/diritems.test.ts
+++ b/src/islands/contextmenu/diritems.test.ts
@@ -1,0 +1,79 @@
+// Tests for the three menu items every folder row shares.
+//
+// Same isolation strategy as fileitems.test.ts, and for the same reason: the
+// copy items pull in legacy/clipboard -> sound -> settings -> legacy/bridge,
+// and an unmocked bridge evaluates legacy/main.ts, which wants a real #cv
+// canvas.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../legacy/bridge", () => ({
+  applyThemeMode: vi.fn(),
+  tama: { set: vi.fn(), say: vi.fn(), warn: vi.fn(), event: vi.fn() },
+}));
+
+vi.mock("../../ipc/bindings", () => ({
+  commands: { openDirInFileManager: vi.fn(async () => ({ status: "ok", data: null })) },
+}));
+
+import { commands } from "../../ipc/bindings";
+import { dirPathMenuItems } from "./diritems.ts";
+
+function byId(items: ReturnType<typeof dirPathMenuItems>, id: string) {
+  const found = items.find((i) => i.id === id);
+  if (!found) throw new Error(`no item ${id}`);
+  return found;
+}
+
+describe("dirPathMenuItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+  });
+
+  it("is the same three items, in the same order, wherever it is used", () => {
+    expect(dirPathMenuItems("/repo", "src/islands").map((i) => i.id)).toEqual(["open-dir", "copy-path", "copy-full-path"]);
+  });
+
+  // These are appended after a surface's own actions, so the divider belongs
+  // on the first of them. ContextMenu.svelte drops it when they are the only
+  // group, which is Detail's folder rows.
+  it("starts a new group", () => {
+    const items = dirPathMenuItems("/repo", "src/islands");
+    expect(byId(items, "open-dir").separatorBefore).toBe(true);
+    expect(byId(items, "copy-path").separatorBefore).toBeFalsy();
+  });
+
+  it("copies the relative folder path, and the joined absolute one", () => {
+    const items = dirPathMenuItems("/repo", "src/islands");
+    byId(items, "copy-path").run();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("src/islands");
+    byId(items, "copy-full-path").run();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/repo/src/islands");
+  });
+
+  it("hands the backend the repo and the relative path, not a pre-joined one", () => {
+    byId(dirPathMenuItems("/repo", "src/islands"), "open-dir").run();
+    expect(commands.openDirInFileManager).toHaveBeenCalledWith("/repo", "src/islands");
+  });
+
+  // A folder is OPENED, not revealed — the two verbs differ, and so does the
+  // command. Revealing would open the folder's parent with it merely
+  // selected, which is the wrong place to be left.
+  it("opens the folder rather than revealing it in its parent", () => {
+    expect(byId(dirPathMenuItems("/repo", "src"), "open-dir").id).toBe("open-dir");
+    expect(dirPathMenuItems("/repo", "src").some((i) => i.id === "reveal")).toBe(false);
+  });
+
+  // No repo means there is nothing to open — possible for a frame while a
+  // repo is being opened or closed.
+  it("disables the open item when there is no repo", () => {
+    expect(byId(dirPathMenuItems("", "src"), "open-dir").disabled).toBe(true);
+  });
+
+  // Unlike a file row's trio there is no disabled-because-missing case: a
+  // folder node exists exactly when something under it does.
+  it("never disables a folder for being absent", () => {
+    const items = dirPathMenuItems("/repo", "src/islands");
+    expect(items.every((i) => !i.disabled)).toBe(true);
+  });
+});

--- a/src/islands/contextmenu/diritems.ts
+++ b/src/islands/contextmenu/diritems.ts
@@ -1,0 +1,51 @@
+// The path items every FOLDER row gets, wherever the row lives.
+//
+// The sibling of fileitems.ts, and split from it for one reason: a folder
+// takes a different verb. See legacy/platform.ts — revealing a file opens the
+// folder containing it with the file selected, which is what you want for a
+// file and never what you want for a folder. A folder is a place you go
+// INSIDE. Same reason `openDirLabelKey` is its own family of strings.
+//
+// Both file trees have folder rows (Detail's commit tree, and Workdir's
+// staged and unstaged trees), and each already has its own actions to put
+// above these, so the trio is built once here for the same reason the file
+// one is.
+
+import { t } from "../../i18n/i18n.svelte.ts";
+import { commands } from "../../ipc/bindings";
+import { copyToClipboard } from "../../legacy/clipboard.ts";
+import { joinRepoPath } from "../../legacy/paths.ts";
+import { openDirLabelKey } from "../../legacy/platform.ts";
+import type { ContextMenuItem } from "./contextmenu.svelte.ts";
+
+/**
+ * Open / copy path / copy full path for the folder at `relative` inside
+ * `repo`.
+ *
+ * `relative` is a tree node's own path: repo-relative, forward slashes, no
+ * trailing slash — the form both trees already build their nodes with. It is
+ * handed to the backend as-is rather than pre-joined, so the join and the
+ * check that it cannot escape the repo stay on the side that acts on it (see
+ * `file_manager.rs`).
+ *
+ * Unlike a file row's trio there is no disabled case: a folder in either tree
+ * is on disk by construction. A commit's tree can contain a file the commit
+ * DELETED, but not a folder that is not there — the tree is built from the
+ * paths of the files in it, so a folder exists exactly when something under
+ * it does.
+ */
+export function dirPathMenuItems(repo: string, relative: string): ContextMenuItem[] {
+  return [
+    {
+      id: "open-dir",
+      label: t(openDirLabelKey()),
+      // The trio always follows a surface's own actions, so the group break
+      // belongs here rather than on whatever happens to come before it.
+      separatorBefore: true,
+      disabled: !repo,
+      run: () => void commands.openDirInFileManager(repo, relative),
+    },
+    { id: "copy-path", label: t("common.copy_path"), run: () => copyToClipboard(relative) },
+    { id: "copy-full-path", label: t("common.copy_full_path"), run: () => copyToClipboard(joinRepoPath(repo, relative)) },
+  ];
+}

--- a/src/islands/contextmenu/diritems.ts
+++ b/src/islands/contextmenu/diritems.ts
@@ -12,7 +12,7 @@
 // one is.
 
 import { t } from "../../i18n/i18n.svelte.ts";
-import { commands } from "../../ipc/bindings";
+import { openDir } from "./filemanager.ts";
 import { copyToClipboard } from "../../legacy/clipboard.ts";
 import { joinRepoPath } from "../../legacy/paths.ts";
 import { openDirLabelKey } from "../../legacy/platform.ts";
@@ -43,7 +43,7 @@ export function dirPathMenuItems(repo: string, relative: string): ContextMenuIte
       // belongs here rather than on whatever happens to come before it.
       separatorBefore: true,
       disabled: !repo,
-      run: () => void commands.openDirInFileManager(repo, relative),
+      run: () => void openDir(repo, relative),
     },
     { id: "copy-path", label: t("common.copy_path"), run: () => copyToClipboard(relative) },
     { id: "copy-full-path", label: t("common.copy_full_path"), run: () => copyToClipboard(joinRepoPath(repo, relative)) },

--- a/src/islands/contextmenu/diritems.ts
+++ b/src/islands/contextmenu/diritems.ts
@@ -7,9 +7,14 @@
 // INSIDE. Same reason `openDirLabelKey` is its own family of strings.
 //
 // Both file trees have folder rows (Detail's commit tree, and Workdir's
-// staged and unstaged trees), and each already has its own actions to put
-// above these, so the trio is built once here for the same reason the file
-// one is.
+// staged and unstaged trees), so the trio is built once here for the same
+// reason the file one is.
+//
+// Unlike the file trio, though, these do not always follow something: a
+// working-tree folder row has stage-or-unstage above them, a commit's folder
+// row has nothing. That is why `separatorBefore` below is marked
+// unconditionally and ContextMenu.svelte drops it at index 0, rather than
+// each caller deciding — the builder cannot see what it is being appended to.
 
 import { t } from "../../i18n/i18n.svelte.ts";
 import { openDir } from "./filemanager.ts";

--- a/src/islands/contextmenu/fileitems.test.ts
+++ b/src/islands/contextmenu/fileitems.test.ts
@@ -1,0 +1,77 @@
+// Tests for the three menu items every file row shares.
+//
+// Same isolation strategy as clipboard.test.ts, and for the same reason: the
+// copy items pull in legacy/clipboard -> sound -> settings -> legacy/bridge,
+// and an unmocked bridge evaluates legacy/main.ts, which wants a real #cv
+// canvas.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../legacy/bridge", () => ({
+  applyThemeMode: vi.fn(),
+  tama: { set: vi.fn(), say: vi.fn(), warn: vi.fn(), event: vi.fn() },
+}));
+
+vi.mock("../../ipc/bindings", () => ({
+  commands: { revealPathInFileManager: vi.fn(async () => ({ status: "ok", data: null })) },
+}));
+
+import { commands } from "../../ipc/bindings";
+import { contextMenuCtrl } from "./contextmenu.svelte.ts";
+import { filePathMenuItems } from "./fileitems.ts";
+
+function byId(items: ReturnType<typeof filePathMenuItems>, id: string) {
+  const found = items.find((i) => i.id === id);
+  if (!found) throw new Error(`no item ${id}`);
+  return found;
+}
+
+describe("filePathMenuItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+  });
+
+  it("is the same three items, in the same order, wherever it is used", () => {
+    expect(filePathMenuItems("/repo", "src/a.ts").map((i) => i.id)).toEqual(["reveal", "copy-path", "copy-full-path"]);
+  });
+
+  // These are appended after a surface's own actions, so the divider belongs
+  // on the first of them — not on whatever happens to precede it.
+  it("starts a new group", () => {
+    const items = filePathMenuItems("/repo", "src/a.ts");
+    expect(byId(items, "reveal").separatorBefore).toBe(true);
+    expect(byId(items, "copy-path").separatorBefore).toBeFalsy();
+  });
+
+  it("copies git's own relative spelling, and the joined absolute path", () => {
+    const items = filePathMenuItems("/repo", "src/a.ts");
+    byId(items, "copy-path").run();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("src/a.ts");
+    byId(items, "copy-full-path").run();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/repo/src/a.ts");
+  });
+
+  it("reveal hands the backend the repo and the relative path, not a pre-joined one", () => {
+    byId(filePathMenuItems("/repo", "src/a.ts"), "reveal").run();
+    expect(commands.revealPathInFileManager).toHaveBeenCalledWith("/repo", "src/a.ts");
+  });
+
+  // `onDisk: false` is the commit-deleted-this-file case. Disabled, not
+  // dropped, so the menu keeps its shape between rows.
+  it("disables reveal when the file is not on disk, leaving both copies live", () => {
+    const items = filePathMenuItems("/repo", "gone.ts", { onDisk: false });
+    expect(byId(items, "reveal").disabled).toBe(true);
+    expect(byId(items, "copy-path").disabled).toBeFalsy();
+    expect(byId(items, "copy-full-path").disabled).toBeFalsy();
+    contextMenuCtrl.open(items, 0, 0);
+    contextMenuCtrl.run(byId(items, "reveal"));
+    expect(commands.revealPathInFileManager).not.toHaveBeenCalled();
+    contextMenuCtrl.close();
+  });
+
+  // No repo means nothing to reveal INTO — possible for a frame while a repo
+  // is being opened or closed.
+  it("disables reveal when there is no repo", () => {
+    expect(byId(filePathMenuItems("", "src/a.ts"), "reveal").disabled).toBe(true);
+  });
+});

--- a/src/islands/contextmenu/fileitems.ts
+++ b/src/islands/contextmenu/fileitems.ts
@@ -1,0 +1,46 @@
+// The three menu items every file row gets, wherever the row lives.
+//
+// Both file lists in the app — a commit's changed files (Detail) and the
+// working tree (Workdir) — want exactly these, in exactly this order, and
+// each already has its own unrelated actions to put above them. Building the
+// trio here means the wording, the ordering, the divider and the
+// disabled rules are decided once instead of drifting apart between two
+// surfaces that look identical to a user.
+
+import { t } from "../../i18n/i18n.svelte.ts";
+import { commands } from "../../ipc/bindings";
+import { copyToClipboard } from "../../legacy/clipboard.ts";
+import { joinRepoPath } from "../../legacy/paths.ts";
+import { revealLabelKey } from "../../legacy/platform.ts";
+import type { ContextMenuItem } from "./contextmenu.svelte.ts";
+
+/**
+ * Reveal / copy path / copy full path for `relative` inside `repo`.
+ *
+ * `relative` is git's own spelling (repo-relative, forward slashes) — the
+ * form both file lists already hold. It is handed to the backend as-is
+ * rather than pre-joined: the join, and the check that it cannot escape the
+ * repo, belong on the side that will act on it (see `file_manager.rs`).
+ *
+ * `onDisk` is false for a file the selected commit DELETED. There is nothing
+ * to show for those, so reveal is disabled — but kept visible, so the menu
+ * does not change shape from row to row and the items below it do not move
+ * under the cursor. Copying a deleted file's path stays useful, and often is
+ * exactly what you wanted it for.
+ */
+export function filePathMenuItems(repo: string, relative: string, opts: { onDisk?: boolean } = {}): ContextMenuItem[] {
+  const onDisk = opts.onDisk !== false;
+  return [
+    {
+      id: "reveal",
+      label: t(revealLabelKey()),
+      // The trio always follows a surface's own actions, so the group break
+      // belongs here rather than on whatever happens to come before it.
+      separatorBefore: true,
+      disabled: !onDisk || !repo,
+      run: () => void commands.revealPathInFileManager(repo, relative),
+    },
+    { id: "copy-path", label: t("common.copy_path"), run: () => copyToClipboard(relative) },
+    { id: "copy-full-path", label: t("common.copy_full_path"), run: () => copyToClipboard(joinRepoPath(repo, relative)) },
+  ];
+}

--- a/src/islands/contextmenu/fileitems.ts
+++ b/src/islands/contextmenu/fileitems.ts
@@ -8,7 +8,7 @@
 // surfaces that look identical to a user.
 
 import { t } from "../../i18n/i18n.svelte.ts";
-import { commands } from "../../ipc/bindings";
+import { revealPath } from "./filemanager.ts";
 import { copyToClipboard } from "../../legacy/clipboard.ts";
 import { joinRepoPath } from "../../legacy/paths.ts";
 import { revealLabelKey } from "../../legacy/platform.ts";
@@ -38,7 +38,7 @@ export function filePathMenuItems(repo: string, relative: string, opts: { onDisk
       // belongs here rather than on whatever happens to come before it.
       separatorBefore: true,
       disabled: !onDisk || !repo,
-      run: () => void commands.revealPathInFileManager(repo, relative),
+      run: () => void revealPath(repo, relative),
     },
     { id: "copy-path", label: t("common.copy_path"), run: () => copyToClipboard(relative) },
     { id: "copy-full-path", label: t("common.copy_full_path"), run: () => copyToClipboard(joinRepoPath(repo, relative)) },

--- a/src/islands/contextmenu/filemanager.ts
+++ b/src/islands/contextmenu/filemanager.ts
@@ -8,6 +8,17 @@
 //
 // Shared by all three item builders rather than repeated in each, since the
 // open half has two callers (a folder row and the topbar repo chip).
+//
+// Both go through our own Rust commands rather than `@tauri-apps/plugin-opener`
+// directly, which is the obvious-looking shortcut and was tried first. The
+// reveal half would work — `opener:default` already allows `revealItemInDir`.
+// The open half will not: `allow-open-path`'s scope check ends in
+// `self.allowed.iter().any(...)`, false for an empty allow list, so the
+// capability has to carry one, and the only pattern wide enough for
+// "whichever repo is open" is `**`. That hands the webview the right to ask
+// the OS to open ANY path with its default application, and this app runs
+// third-party plugin code in that webview. `src-tauri/src/file_manager.rs`
+// carries the full reasoning and the trust gate.
 
 import { be, t } from "../../i18n/i18n.svelte.ts";
 import * as bridge from "../../legacy/bridge";

--- a/src/islands/contextmenu/filemanager.ts
+++ b/src/islands/contextmenu/filemanager.ts
@@ -1,0 +1,26 @@
+// The two file-manager menu actions, with their errors actually shown.
+//
+// Both commands can genuinely fail — most often on a file from an older commit
+// that is no longer on disk, where the OS file manager refuses the path. The
+// menu items used to `void` the promise, so that case did nothing at all: the
+// menu closed, no window opened, and no explanation appeared. Warning through
+// Tama matches how every other failed command in this app reports itself.
+//
+// Shared by all three item builders rather than repeated in each, since the
+// open half has two callers (a folder row and the topbar repo chip).
+
+import { be, t } from "../../i18n/i18n.svelte.ts";
+import * as bridge from "../../legacy/bridge";
+import { commands } from "../../ipc/bindings";
+
+/** Open the containing folder with `relative` selected. */
+export async function revealPath(repo: string, relative: string): Promise<void> {
+  const r = await commands.revealPathInFileManager(repo, relative);
+  if (r.status === "error") bridge.tama.warn(t("common.warn_reveal_failed", { reason: be(r.error) }));
+}
+
+/** Open a directory itself — `relative` empty means the repository. */
+export async function openDir(repo: string, relative: string): Promise<void> {
+  const r = await commands.openDirInFileManager(repo, relative);
+  if (r.status === "error") bridge.tama.warn(t("common.warn_open_dir_failed", { reason: be(r.error) }));
+}

--- a/src/islands/contextmenu/repoitems.test.ts
+++ b/src/islands/contextmenu/repoitems.test.ts
@@ -1,0 +1,73 @@
+// Tests for the topbar repo chip's right-click menu.
+//
+// Same isolation reasoning as fileitems.test.ts: the copy item reaches
+// legacy/clipboard -> sound -> settings -> legacy/bridge, and an unmocked
+// bridge evaluates legacy/main.ts.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../legacy/bridge", () => ({
+  applyThemeMode: vi.fn(),
+  tama: { set: vi.fn(), say: vi.fn(), warn: vi.fn(), event: vi.fn() },
+}));
+
+vi.mock("../../ipc/bindings", () => ({
+  commands: { openDirInFileManager: vi.fn(async () => ({ status: "ok", data: null })) },
+}));
+
+vi.mock("../terminal/terminal.svelte.ts", () => ({
+  terminalCtrl: { toggle: vi.fn(async () => {}) },
+}));
+
+import { commands } from "../../ipc/bindings";
+import { terminalCtrl } from "../terminal/terminal.svelte.ts";
+import { repoMenuItems } from "./repoitems.ts";
+
+function byId(items: ReturnType<typeof repoMenuItems>, id: string) {
+  const found = items.find((i) => i.id === id);
+  if (!found) throw new Error(`no item ${id}; got ${items.map((i) => i.id).join(", ")}`);
+  return found;
+}
+
+describe("repoMenuItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn() } });
+  });
+
+  it("offers a terminal, the file manager, and the path", () => {
+    expect(repoMenuItems("/repo").map((i) => i.id)).toEqual(["terminal", "open-dir", "copy-path"]);
+  });
+
+  // The built-in drawer, not an OS terminal window. GitCat replaced the
+  // shell-out deliberately (see src-tauri/src/terminal.rs's module doc), and a
+  // menu item that reopened that decision would be a regression in disguise.
+  it("opens the built-in terminal at the repo", () => {
+    byId(repoMenuItems("/repo"), "terminal").run();
+    expect(terminalCtrl.toggle).toHaveBeenCalledWith("/repo");
+  });
+
+  // open, not reveal: a repo is a folder you want to land inside, whereas
+  // revealing a directory opens its PARENT with the repo merely selected.
+  //
+  // The empty relative is what makes the repo chip and a folder row share one
+  // command — see diritems.ts. Pinned here so a later "tidy up the unused
+  // argument" cannot silently split them apart again.
+  it("opens the repo folder itself, via the same command a folder row uses", () => {
+    byId(repoMenuItems("/repo"), "open-dir").run();
+    expect(commands.openDirInFileManager).toHaveBeenCalledWith("/repo", "");
+  });
+
+  it("copies the repo's own absolute path", () => {
+    byId(repoMenuItems("C:\\Users\\me\\proj"), "copy-path").run();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("C:\\Users\\me\\proj");
+  });
+
+  // With no repo open the chip is a "pick a repo" button, and every item here
+  // would act on nothing. An empty list means contextMenuCtrl.open() is a
+  // no-op, so the right-click falls through to no menu at all rather than a
+  // box of dead entries.
+  it("has nothing to offer when no repo is open", () => {
+    expect(repoMenuItems("")).toEqual([]);
+    expect(repoMenuItems(null as unknown as string)).toEqual([]);
+  });
+});

--- a/src/islands/contextmenu/repoitems.ts
+++ b/src/islands/contextmenu/repoitems.ts
@@ -1,0 +1,46 @@
+// The topbar repo chip's right-click menu.
+//
+// GitCat has no repo tabs to hang this on — one repo per window, by design
+// (see src-tauri/src/windows.rs) — so the chip that names the open repo is
+// where the repo-level actions live.
+
+import { t } from "../../i18n/i18n.svelte.ts";
+import { commands } from "../../ipc/bindings";
+import { copyToClipboard } from "../../legacy/clipboard.ts";
+import { openDirLabelKey } from "../../legacy/platform.ts";
+import { terminalCtrl } from "../terminal/terminal.svelte.ts";
+import type { ContextMenuItem } from "./contextmenu.svelte.ts";
+
+/**
+ * Terminal / open in file manager / copy path, for the currently open repo.
+ *
+ * Empty when no repo is open: the chip is a "pick a repo" button then, and
+ * every action here would apply to nothing. `contextMenuCtrl.open([])` is a
+ * no-op, so the right-click simply produces no menu rather than a box of
+ * dead entries.
+ */
+export function repoMenuItems(repo: string): ContextMenuItem[] {
+  if (!repo) return [];
+  return [
+    {
+      id: "terminal",
+      // The built-in drawer, not an OS terminal window. GitCat replaced the
+      // old shell-out-to-Terminal.app action with this on purpose (see
+      // src-tauri/src/terminal.rs's module doc); a menu entry that launched
+      // an external terminal would quietly undo that.
+      label: t("menu.open_terminal"),
+      run: () => void terminalCtrl.toggle(repo),
+    },
+    {
+      id: "open-dir",
+      label: t(openDirLabelKey()),
+      // open_path, not reveal: a repo is a folder you want to be inside.
+      // Revealing a directory opens its PARENT with the repo selected.
+      //
+      // The empty relative is the repo itself — the same command a folder row
+      // uses, so the two cannot drift apart (see diritems.ts).
+      run: () => void commands.openDirInFileManager(repo, ""),
+    },
+    { id: "copy-path", label: t("common.copy_path"), run: () => copyToClipboard(repo) },
+  ];
+}

--- a/src/islands/contextmenu/repoitems.ts
+++ b/src/islands/contextmenu/repoitems.ts
@@ -5,7 +5,7 @@
 // where the repo-level actions live.
 
 import { t } from "../../i18n/i18n.svelte.ts";
-import { commands } from "../../ipc/bindings";
+import { openDir } from "./filemanager.ts";
 import { copyToClipboard } from "../../legacy/clipboard.ts";
 import { openDirLabelKey } from "../../legacy/platform.ts";
 import { terminalCtrl } from "../terminal/terminal.svelte.ts";
@@ -39,7 +39,7 @@ export function repoMenuItems(repo: string): ContextMenuItem[] {
       //
       // The empty relative is the repo itself — the same command a folder row
       // uses, so the two cannot drift apart (see diritems.ts).
-      run: () => void commands.openDirInFileManager(repo, ""),
+      run: () => void openDir(repo, ""),
     },
     { id: "copy-path", label: t("common.copy_path"), run: () => copyToClipboard(repo) },
   ];

--- a/src/islands/detail/Detail.svelte
+++ b/src/islands/detail/Detail.svelte
@@ -382,7 +382,12 @@
       open={!detailCtrl.isDirCollapsed(child.path)}
       ontoggle={(e) => detailCtrl.setDirOpen(child.path, (e.currentTarget as HTMLDetailsElement).open)}
     >
-      <summary title={child.path}><span class="tw">&#9656;</span><Folder class="ico" size={13} aria-hidden="true" /> {name}</summary>
+      <summary
+        title={child.path}
+        oncontextmenu={(e) => {
+          e.preventDefault();
+          detailCtrl.openDirMenu(child.path, e.clientX, e.clientY);
+        }}><span class="tw">&#9656;</span><Folder class="ico" size={13} aria-hidden="true" /> {name}</summary>
       <div class="indent">{@render dirNode(child)}</div>
     </details>
   {/each}
@@ -395,6 +400,14 @@
       role="button"
       tabindex="0"
       onkeydown={(e) => (e.key === "Enter" || e.key === " ") && detailCtrl.selectFile(f.p)}
+      oncontextmenu={(e) => {
+        e.preventDefault();
+        // Select first: the menu's actions all read as "…this file", and a
+        // menu acting on a row that isn't the highlighted one is the kind of
+        // mismatch that gets reported as data loss.
+        detailCtrl.selectFile(f.p);
+        detailCtrl.openFileMenu(f, e.clientX, e.clientY);
+      }}
     >
       <span class="st {f.st === 'A' ? 'A' : f.st === 'D' ? 'D' : 'M'}">{f.st}</span>
       <span class="fname">{f.name}</span>

--- a/src/islands/detail/detail.svelte.test.ts
+++ b/src/islands/detail/detail.svelte.test.ts
@@ -50,11 +50,13 @@ import { resolver } from "../resolver/resolver.svelte.ts";
 import { blameCtrl } from "../blame/blame.svelte.ts";
 import { fileHistoryCtrl } from "../filehistory/filehistory.svelte.ts";
 import { detailCtrl } from "./detail.svelte.ts";
+import { contextMenuCtrl } from "../contextmenu/contextmenu.svelte.ts";
 
 vi.mock("../../ipc/bindings", () => ({
   commands: {
     commitDetail: vi.fn(),
     plumbingInspect: vi.fn(),
+    revealPathInFileManager: vi.fn(async () => ({ status: "ok", data: null })),
   },
 }));
 
@@ -667,5 +669,81 @@ describe("long commit-message body toggle", () => {
     expect(detailCtrl.bodyExpanded).toBe(true);
     detailCtrl.select(1);
     expect(detailCtrl.bodyExpanded).toBe(false);
+  });
+});
+
+describe("file row context menu", () => {
+  const modified = { p: "src/main.rs", st: "M", oldPath: null, name: "main.rs", add: 1, del: 0, i: 0 };
+  const deleted = { p: "old/gone.rs", st: "D", oldPath: null, name: "gone.rs", add: 0, del: 9, i: 1 };
+
+  // Addressed by id, not label: the labels are translated, and one of them
+  // is platform-dependent (see legacy/platform.ts), so asserting on text
+  // would make this test depend on the locale and the user agent.
+  function ids() {
+    return (contextMenuCtrl.menu?.items ?? []).map((i) => i.id);
+  }
+  function item(id: string) {
+    const found = (contextMenuCtrl.menu?.items ?? []).find((i) => i.id === id);
+    if (!found) throw new Error(`no menu item ${id}; got ${ids().join(", ")}`);
+    return found;
+  }
+
+  beforeEach(() => {
+    contextMenuCtrl.close();
+    setDemoGraph();
+    detailCtrl.select(0);
+  });
+
+  // The three actions the row already had as icon buttons come first, then a
+  // divider, then the three this menu adds. Right-clicking should show
+  // everything that can be done to the file, not a second, smaller set.
+  it("offers the row's existing actions and the new ones, in that order", () => {
+    detailCtrl.openFileMenu(modified, 10, 20);
+    expect(ids()).toEqual(["blame", "history", "external-diff", "reveal", "copy-path", "copy-full-path"]);
+    expect(contextMenuCtrl.menu?.x).toBe(10);
+    expect(contextMenuCtrl.menu?.y).toBe(20);
+    expect(item("reveal").separatorBefore).toBe(true);
+  });
+
+  it("copy path puts git's own repo-relative spelling on the clipboard", () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    detailCtrl.openFileMenu(modified, 0, 0);
+    contextMenuCtrl.run(item("copy-path"));
+    expect(writeText).toHaveBeenCalledWith("src/main.rs");
+  });
+
+  it("copy full path joins it onto the repo", () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    detailCtrl.openFileMenu(modified, 0, 0);
+    contextMenuCtrl.run(item("copy-full-path"));
+    expect(writeText).toHaveBeenCalledWith("/repo/src/main.rs");
+  });
+
+  it("reveal asks the backend for the repo plus the relative path", () => {
+    detailCtrl.openFileMenu(modified, 0, 0);
+    contextMenuCtrl.run(item("reveal"));
+    expect(commands.revealPathInFileManager).toHaveBeenCalledWith("/repo", "src/main.rs");
+  });
+
+  // A commit's file list includes what that commit DELETED. There is nothing
+  // on disk to show, so the item is disabled rather than left to fail — but
+  // it stays visible so the menu keeps the same shape from row to row.
+  it("disables reveal for a file the commit deleted, without hiding it", () => {
+    vi.mocked(commands.revealPathInFileManager).mockClear();
+    detailCtrl.openFileMenu(deleted, 0, 0);
+    expect(ids()).toContain("reveal");
+    expect(item("reveal").disabled).toBe(true);
+    contextMenuCtrl.run(item("reveal"));
+    expect(commands.revealPathInFileManager).not.toHaveBeenCalled();
+  });
+
+  // Copying a path is still meaningful for a deleted file — you often want
+  // it precisely to go looking for what happened to it.
+  it("still offers both copies for a deleted file", () => {
+    detailCtrl.openFileMenu(deleted, 0, 0);
+    expect(item("copy-path").disabled).toBeFalsy();
+    expect(item("copy-full-path").disabled).toBeFalsy();
   });
 });

--- a/src/islands/detail/detail.svelte.ts
+++ b/src/islands/detail/detail.svelte.ts
@@ -23,6 +23,9 @@ import { externalToolsCtrl } from "../externaltools/externaltools.svelte.ts";
 import { IN_TAURI } from "../../ipc/env";
 import { previewKind } from "../diffpreview/preview-kind";
 import { copyToClipboard } from "../../legacy/clipboard.ts";
+import { contextMenuCtrl } from "../contextmenu/contextmenu.svelte.ts";
+import { filePathMenuItems } from "../contextmenu/fileitems.ts";
+import { dirPathMenuItems } from "../contextmenu/diritems.ts";
 
 function esc(s: unknown): string {
   return String(s).replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] as string);
@@ -537,6 +540,46 @@ class DetailState {
     if (!c) return;
     const repo = bridge.CUR_REPO as unknown as string;
     void externalToolsCtrl.openDiff(repo, f.p, false, c.sha + "^", c.sha);
+  }
+
+  // Right-click menu for a file row (see Detail.svelte's file tree). Carries
+  // the three actions the row already exposes as icon buttons — a context
+  // menu that offered LESS than the visible buttons would be a strange thing
+  // to discover — then, after a divider, the three this menu exists for.
+  //
+  // `reveal` is the one item that can be inapplicable: a commit's file list
+  // includes what that commit DELETED, and there is nothing on disk to show
+  // for those. It is disabled rather than dropped, so the menu keeps the same
+  // shape from row to row and the items below it don't move under the cursor.
+  // Both copies stay live even then — a deleted file's path is often exactly
+  // what you want, to go and find out what happened to it.
+  openFileMenu(f: { p: string; st: string; oldPath: string | null }, x: number, y: number): void {
+    const repo = bridge.CUR_REPO as unknown as string;
+    const gone = f.st === "D";
+    contextMenuCtrl.open(
+      [
+        { id: "blame", label: t("detail.blame"), run: () => void this.blameFile(f) },
+        { id: "history", label: t("detail.history"), run: () => void this.historyFile(f) },
+        { id: "external-diff", label: t("detail.open_external_diff"), run: () => this.openExternalDiff(f) },
+        ...filePathMenuItems(repo, f.p, { onDisk: !gone }),
+      ],
+      x,
+      y,
+    );
+  }
+
+  // Right-click menu for a FOLDER row in the same tree. Folder rows carry no
+  // icon buttons of their own here, so this is the path trio alone — a
+  // directory has no blame, no history, and no diff of its own to open.
+  //
+  // Deliberately not a plain reuse of openFileMenu: a folder takes the other
+  // verb (see contextmenu/diritems.ts). Nothing is selected first either,
+  // unlike a file row — a folder is not a diff target, so `selectedFile`
+  // would have to be cleared or left pointing somewhere unrelated, and both
+  // are worse than leaving the current selection alone.
+  openDirMenu(path: string, x: number, y: number): void {
+    const repo = bridge.CUR_REPO as unknown as string;
+    contextMenuCtrl.open(dirPathMenuItems(repo, path), x, y);
   }
 
   expandDiff() {

--- a/src/islands/workdir/Workdir.svelte
+++ b/src/islands/workdir/Workdir.svelte
@@ -460,29 +460,6 @@
 <!-- Per-file right-click menu (opened from an unstaged file row's contextmenu).
      A transparent full-screen backdrop dismisses it on the next click/right-
      click, like the app's other popovers. -->
-{#if workdirCtrl.rowMenu}
-  <div
-    class="wd-rowmenu-backdrop"
-    role="presentation"
-    onclick={() => workdirCtrl.closeRowMenu()}
-    oncontextmenu={(e) => {
-      e.preventDefault();
-      workdirCtrl.closeRowMenu();
-    }}
-  ></div>
-  <div class="wd-rowmenu" style="left:{workdirCtrl.rowMenu.x}px; top:{workdirCtrl.rowMenu.y}px">
-    <button
-      class="wd-rowmenu-item danger"
-      disabled={workdirCtrl.busy}
-      onclick={() => {
-        const m = workdirCtrl.rowMenu;
-        workdirCtrl.closeRowMenu();
-        if (m) workdirCtrl.confirmDiscard(m.file, m.untracked);
-      }}>{t("workdir.discard_changes")}</button
-    >
-  </div>
-{/if}
-
 <!-- The uncommitted-changes Diff, reused by the inline panel above and the
      expanded .diffx modal: a "lines selected" action bar and the file's diff
      body (per-hunk toolbar + per-line staging checkboxes). -->
@@ -624,7 +601,10 @@
       ontoggle={(e) => workdirCtrl.setDirOpen("staged", child.path, (e.currentTarget as HTMLDetailsElement).open)}
     >
       <summary
-        ><span class="tw">&#9656;</span><Folder class="ico" size={13} aria-hidden="true" /><span class="wd-path">{name}</span>
+        oncontextmenu={(e) => {
+          e.preventDefault();
+          workdirCtrl.openDirRowMenu(child.path, true, e.clientX, e.clientY);
+        }}><span class="tw">&#9656;</span><Folder class="ico" size={13} aria-hidden="true" /><span class="wd-path">{name}</span>
         {#if workdirCtrl.busyTarget === child.path}
           <span class="spinner"></span>
         {:else}
@@ -654,6 +634,12 @@
       role="button"
       tabindex="0"
       onclick={() => workdirCtrl.selectDiffFile(f.path, true)}
+      oncontextmenu={(e) => {
+        e.preventDefault();
+        // Select first, so the menu always acts on the highlighted row.
+        workdirCtrl.selectDiffFile(f.path, true);
+        workdirCtrl.openRowMenu(f.path, f.status === "?", true, e.clientX, e.clientY);
+      }}
       onkeydown={(e) => (e.key === "Enter" || e.key === " ") && workdirCtrl.selectDiffFile(f.path, true)}
     >
       <span class="st" data-status={f.status}>{STATUS_LABEL[f.status] ?? f.status}</span>
@@ -717,7 +703,10 @@
       ontoggle={(e) => workdirCtrl.setDirOpen("unstaged", child.path, (e.currentTarget as HTMLDetailsElement).open)}
     >
       <summary
-        ><span class="tw">&#9656;</span><Folder class="ico" size={13} aria-hidden="true" /><span class="wd-path">{name}</span>
+        oncontextmenu={(e) => {
+          e.preventDefault();
+          workdirCtrl.openDirRowMenu(child.path, false, e.clientX, e.clientY);
+        }}><span class="tw">&#9656;</span><Folder class="ico" size={13} aria-hidden="true" /><span class="wd-path">{name}</span>
         {#if workdirCtrl.busyTarget === child.path}
           <span class="spinner"></span>
         {:else}
@@ -750,7 +739,8 @@
       onkeydown={(e) => (e.key === "Enter" || e.key === " ") && workdirCtrl.selectDiffFile(f.path, false)}
       oncontextmenu={(e) => {
         e.preventDefault();
-        workdirCtrl.openRowMenu(f.path, f.status === "?", e.clientX, e.clientY);
+        workdirCtrl.selectDiffFile(f.path, false);
+        workdirCtrl.openRowMenu(f.path, f.status === "?", false, e.clientX, e.clientY);
       }}
     >
       <span class="st" data-status={f.status}>{STATUS_LABEL[f.status] ?? f.status}</span>

--- a/src/islands/workdir/Workdir.svelte
+++ b/src/islands/workdir/Workdir.svelte
@@ -638,7 +638,7 @@
         e.preventDefault();
         // Select first, so the menu always acts on the highlighted row.
         workdirCtrl.selectDiffFile(f.path, true);
-        workdirCtrl.openRowMenu(f.path, f.status === "?", true, e.clientX, e.clientY);
+        workdirCtrl.openRowMenu(f.path, f.status === "?", true, f.status !== "D", e.clientX, e.clientY);
       }}
       onkeydown={(e) => (e.key === "Enter" || e.key === " ") && workdirCtrl.selectDiffFile(f.path, true)}
     >
@@ -740,7 +740,7 @@
       oncontextmenu={(e) => {
         e.preventDefault();
         workdirCtrl.selectDiffFile(f.path, false);
-        workdirCtrl.openRowMenu(f.path, f.status === "?", false, e.clientX, e.clientY);
+        workdirCtrl.openRowMenu(f.path, f.status === "?", false, f.status !== "D", e.clientX, e.clientY);
       }}
     >
       <span class="st" data-status={f.status}>{STATUS_LABEL[f.status] ?? f.status}</span>

--- a/src/islands/workdir/workdir.svelte.test.ts
+++ b/src/islands/workdir/workdir.svelte.test.ts
@@ -55,6 +55,8 @@ import { commands } from "../../ipc/bindings";
 import { resolver } from "../resolver/resolver.svelte.ts";
 import { tamaConfirmCtrl } from "../tamaconfirm/tamaconfirm.svelte.ts";
 import { workdirCtrl, canBlameWorkdirFile, blameTargetForWorkdirFile, buildWdTree } from "./workdir.svelte.ts";
+import { contextMenuCtrl } from "../contextmenu/contextmenu.svelte.ts";
+import type { ContextMenuItem } from "../contextmenu/contextmenu.svelte.ts";
 import type { FileChange, HunkSelection, StashEntry, WorkdirEntry, WorkdirResult, WorkdirStatus } from "../../ipc/bindings";
 
 function ok<T>(data: T): { status: "ok"; data: T } {
@@ -548,12 +550,42 @@ describe("discard all (stash-backed)", () => {
     expect(bridge.tama.set).toHaveBeenCalledWith("celebrate");
   });
 
-  it("openRowMenu/closeRowMenu drive the per-file right-click menu state", () => {
-    expect(workdirCtrl.rowMenu).toBe(null);
-    workdirCtrl.openRowMenu("b.ts", false, 120, 240);
-    expect(workdirCtrl.rowMenu).toEqual({ file: "b.ts", untracked: false, x: 120, y: 240 });
-    workdirCtrl.closeRowMenu();
-    expect(workdirCtrl.rowMenu).toBe(null);
+  // The per-file right-click menu now renders through the shared contextmenu
+  // island (see contextmenu.svelte.ts), so what this asserts is the item list
+  // the controller builds, not a popover state of its own.
+  it("offers stage for an unstaged row, and unstage for a staged one", () => {
+    workdirCtrl.openRowMenu("b.ts", false, false, 120, 240);
+    expect(contextMenuCtrl.menu?.items.map((i: ContextMenuItem) => i.id)).toEqual(["stage", "discard", "reveal", "copy-path", "copy-full-path"]);
+    expect(contextMenuCtrl.menu?.x).toBe(120);
+    expect(contextMenuCtrl.menu?.y).toBe(240);
+
+    workdirCtrl.openRowMenu("b.ts", false, true, 0, 0);
+    expect(contextMenuCtrl.menu?.items.map((i: ContextMenuItem) => i.id)).toEqual(["unstage", "discard", "reveal", "copy-path", "copy-full-path"]);
+    contextMenuCtrl.close();
+  });
+
+  it("discard is the destructive one, and routes through the same typed confirm as the row button", () => {
+    workdirCtrl.openRowMenu("b.ts", true, false, 0, 0);
+    const discard = contextMenuCtrl.menu?.items.find((i: ContextMenuItem) => i.id === "discard");
+    expect(discard?.danger).toBe(true);
+    contextMenuCtrl.run(discard!);
+    // confirmDiscard arms the shared typed-confirm scrim rather than deleting
+    // anything itself — the menu item is a route to the same guard the row's
+    // trash button already goes through, not a shortcut past it.
+    expect(bridge.tama.set).toHaveBeenCalledWith("danger");
+  });
+
+  // Every item is unrunnable mid-operation, exactly as the row buttons are:
+  // firing a second stage/discard while one is in flight is how a working
+  // tree ends up in a state nobody asked for.
+  it("disables its own actions while the panel is busy", () => {
+    workdirCtrl.busy = true;
+    workdirCtrl.openRowMenu("b.ts", false, false, 0, 0);
+    const items = contextMenuCtrl.menu?.items ?? [];
+    expect(items.find((i: ContextMenuItem) => i.id === "stage")?.disabled).toBe(true);
+    expect(items.find((i: ContextMenuItem) => i.id === "discard")?.disabled).toBe(true);
+    workdirCtrl.busy = false;
+    contextMenuCtrl.close();
   });
 });
 

--- a/src/islands/workdir/workdir.svelte.test.ts
+++ b/src/islands/workdir/workdir.svelte.test.ts
@@ -554,18 +554,40 @@ describe("discard all (stash-backed)", () => {
   // island (see contextmenu.svelte.ts), so what this asserts is the item list
   // the controller builds, not a popover state of its own.
   it("offers stage for an unstaged row, and unstage for a staged one", () => {
-    workdirCtrl.openRowMenu("b.ts", false, false, 120, 240);
+    workdirCtrl.openRowMenu("b.ts", false, false, true, 120, 240);
     expect(contextMenuCtrl.menu?.items.map((i: ContextMenuItem) => i.id)).toEqual(["stage", "discard", "reveal", "copy-path", "copy-full-path"]);
     expect(contextMenuCtrl.menu?.x).toBe(120);
     expect(contextMenuCtrl.menu?.y).toBe(240);
 
-    workdirCtrl.openRowMenu("b.ts", false, true, 0, 0);
-    expect(contextMenuCtrl.menu?.items.map((i: ContextMenuItem) => i.id)).toEqual(["unstage", "discard", "reveal", "copy-path", "copy-full-path"]);
+    workdirCtrl.openRowMenu("b.ts", false, true, true, 0, 0);
+    expect(contextMenuCtrl.menu?.items.map((i: ContextMenuItem) => i.id)).toEqual(["unstage", "reveal", "copy-path", "copy-full-path"]);
+    contextMenuCtrl.close();
+  });
+
+  // A staged row's `untracked` is always false, so discard would take
+  // discardFile's tracked branch and act on the WORKTREE — failing outright
+  // when there is no unstaged delta to back up, and silently throwing away
+  // the unstaged edits when there is. Neither is what the word means here,
+  // and the staged rows carry no trash button either.
+  it("does not offer discard on a staged row", () => {
+    workdirCtrl.openRowMenu("b.ts", false, true, true, 0, 0);
+    expect(contextMenuCtrl.menu?.items.some((i: ContextMenuItem) => i.id === "discard")).toBe(false);
+    contextMenuCtrl.close();
+  });
+
+  // A file the working tree lists as deleted has nothing to show, so reveal
+  // is disabled — the same rule the commit view's rows already follow. Both
+  // copies stay live: a gone file's path is often exactly what you want.
+  it("disables reveal for a row that is no longer on disk", () => {
+    workdirCtrl.openRowMenu("gone.ts", false, false, false, 0, 0);
+    const items = contextMenuCtrl.menu?.items ?? [];
+    expect(items.find((i: ContextMenuItem) => i.id === "reveal")?.disabled).toBe(true);
+    expect(items.find((i: ContextMenuItem) => i.id === "copy-path")?.disabled).toBeFalsy();
     contextMenuCtrl.close();
   });
 
   it("discard is the destructive one, and routes through the same typed confirm as the row button", () => {
-    workdirCtrl.openRowMenu("b.ts", true, false, 0, 0);
+    workdirCtrl.openRowMenu("b.ts", true, false, true, 0, 0);
     const discard = contextMenuCtrl.menu?.items.find((i: ContextMenuItem) => i.id === "discard");
     expect(discard?.danger).toBe(true);
     contextMenuCtrl.run(discard!);
@@ -580,7 +602,7 @@ describe("discard all (stash-backed)", () => {
   // tree ends up in a state nobody asked for.
   it("disables its own actions while the panel is busy", () => {
     workdirCtrl.busy = true;
-    workdirCtrl.openRowMenu("b.ts", false, false, 0, 0);
+    workdirCtrl.openRowMenu("b.ts", false, false, true, 0, 0);
     const items = contextMenuCtrl.menu?.items ?? [];
     expect(items.find((i: ContextMenuItem) => i.id === "stage")?.disabled).toBe(true);
     expect(items.find((i: ContextMenuItem) => i.id === "discard")?.disabled).toBe(true);

--- a/src/islands/workdir/workdir.svelte.ts
+++ b/src/islands/workdir/workdir.svelte.ts
@@ -69,6 +69,10 @@ import { resolver } from "../resolver/resolver.svelte.ts";
 import { tamaConfirmCtrl } from "../tamaconfirm/tamaconfirm.svelte.ts";
 import { IN_TAURI } from "../../ipc/env";
 import { ICON_BACKUP } from "../../legacy/icons";
+import { t } from "../../i18n/i18n.svelte.ts";
+import { contextMenuCtrl } from "../contextmenu/contextmenu.svelte.ts";
+import { filePathMenuItems } from "../contextmenu/fileitems.ts";
+import { dirPathMenuItems } from "../contextmenu/diritems.ts";
 import type { DiffLineRow, FileChange, HunkSelection, SelectedLine, StashEntry, WorkdirEntry, WorkdirStatus } from "../../ipc/bindings";
 
 function esc(s: unknown): string {
@@ -825,16 +829,69 @@ class WorkdirState {
     }
   }
 
-  // Per-file right-click menu (see Workdir.svelte's file rows). Position is the
-  // click point; `untracked` is the row's status === "?" so confirmDiscard picks
-  // the right git op. `closeRowMenu` is also wired to a window click/scroll so
-  // the menu dismisses like any popover.
-  rowMenu = $state<{ file: string; untracked: boolean; x: number; y: number } | null>(null);
-  openRowMenu(file: string, untracked: boolean, x: number, y: number): void {
-    this.rowMenu = { file, untracked, x, y };
+  // Per-file right-click menu (see Workdir.svelte's file rows). `untracked` is
+  // the row's status === "?" so confirmDiscard picks the right git op;
+  // `staged` picks between staging and unstaging, since one row list is the
+  // index and the other the working tree.
+  //
+  // Renders through the shared contextmenu island rather than the popover this
+  // file used to hand-roll — see contextmenu.svelte.ts's header for why one
+  // exists. Dismissal, viewport clamping and closing-before-running all come
+  // from there now, so `closeRowMenu` is gone with the markup that needed it.
+  //
+  // Blame / History / external diff are NOT here even though the row shows
+  // buttons for them: whether they apply to a given row is decided by
+  // canBlameWorkdirFile()/blameTargetForWorkdirFile() in Workdir.svelte, which
+  // is where that per-status knowledge lives. Duplicating those rules here to
+  // gain three menu entries would be the kind of second copy that goes stale.
+  // The commit-side menu (detailCtrl.openFileMenu) has no such split and does
+  // carry all of its row's actions.
+  openRowMenu(file: string, untracked: boolean, staged: boolean, x: number, y: number): void {
+    const repo = this.repo;
+    contextMenuCtrl.open(
+      [
+        staged
+          ? { id: "unstage", label: t("workdir.unstage"), disabled: this.busy, run: () => void this.unstageFile(repo, file) }
+          : { id: "stage", label: t("workdir.stage"), disabled: this.busy, run: () => void this.stageFile(repo, file) },
+        {
+          id: "discard",
+          label: t("workdir.discard_changes"),
+          danger: true,
+          disabled: this.busy,
+          run: () => this.confirmDiscard(file, untracked),
+        },
+        ...filePathMenuItems(repo, file),
+      ],
+      x,
+      y,
+    );
   }
-  closeRowMenu(): void {
-    this.rowMenu = null;
+
+  // Right-click menu for a FOLDER row in either tree.
+  //
+  // Carries the one action the row already exposes as an icon button, for the
+  // same reason a file row's menu carries its three: a menu offering LESS
+  // than the visible buttons is a strange thing to discover. Staging a folder
+  // is `git add` on the directory, which is exactly what the button does —
+  // stageFile/unstageFile take a path, and neither cares that it names a
+  // directory.
+  //
+  // No discard: the button row has none either, and a typed-confirm scrim
+  // naming a whole directory is a different, much larger decision than
+  // discarding one file. Nothing is selected first — a folder is not a diff
+  // target.
+  openDirRowMenu(path: string, staged: boolean, x: number, y: number): void {
+    const repo = this.repo;
+    contextMenuCtrl.open(
+      [
+        staged
+          ? { id: "unstage", label: t("workdir.unstage_folder"), disabled: this.busy, run: () => void this.unstageFile(repo, path) }
+          : { id: "stage", label: t("workdir.stage_folder"), disabled: this.busy, run: () => void this.stageFile(repo, path) },
+        ...dirPathMenuItems(repo, path),
+      ],
+      x,
+      y,
+    );
   }
 
   // ── discard (destructive — routes through the shared typed-confirm scrim

--- a/src/islands/workdir/workdir.svelte.ts
+++ b/src/islands/workdir/workdir.svelte.ts
@@ -846,21 +846,34 @@ class WorkdirState {
   // gain three menu entries would be the kind of second copy that goes stale.
   // The commit-side menu (detailCtrl.openFileMenu) has no such split and does
   // carry all of its row's actions.
-  openRowMenu(file: string, untracked: boolean, staged: boolean, x: number, y: number): void {
+  openRowMenu(file: string, untracked: boolean, staged: boolean, onDisk: boolean, x: number, y: number): void {
     const repo = this.repo;
     contextMenuCtrl.open(
       [
         staged
           ? { id: "unstage", label: t("workdir.unstage"), disabled: this.busy, run: () => void this.unstageFile(repo, file) }
           : { id: "stage", label: t("workdir.stage"), disabled: this.busy, run: () => void this.stageFile(repo, file) },
-        {
-          id: "discard",
-          label: t("workdir.discard_changes"),
-          danger: true,
-          disabled: this.busy,
-          run: () => this.confirmDiscard(file, untracked),
-        },
-        ...filePathMenuItems(repo, file),
+        // Unstaged rows only. A staged row's `untracked` is always false, so
+        // discard would take discardFile's tracked branch and act on the
+        // WORKTREE: for a file staged with no unstaged edits there is no
+        // index-to-worktree delta to back up and the call fails after the user
+        // has typed the filename to confirm; for a file in both lists it throws
+        // away the unstaged edits and leaves the staged change untouched.
+        // Neither is what "discard" reads as on the staged side — and the
+        // staged rows carry no trash button either, so offering it here would
+        // also break the rule the rest of these menus follow.
+        ...(staged
+          ? []
+          : [
+              {
+                id: "discard",
+                label: t("workdir.discard_changes"),
+                danger: true,
+                disabled: this.busy,
+                run: () => this.confirmDiscard(file, untracked),
+              },
+            ]),
+        ...filePathMenuItems(repo, file, { onDisk }),
       ],
       x,
       y,

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -15,6 +15,8 @@ import { displayChips } from "./reforder.ts";
 import { LruCache } from "./graphcache.ts";
 import { clampResize, dragCeiling } from "./resize.ts";
 import { dashboardCtrl } from "../islands/dashboard/dashboard.svelte.ts";
+import { contextMenuCtrl } from "../islands/contextmenu/contextmenu.svelte.ts";
+import { repoMenuItems } from "../islands/contextmenu/repoitems.ts";
 import { repoSummaryCtrl } from "../islands/reposummary/reposummary.svelte.ts";
 import { pluginHooksCtrl } from "../islands/pluginhooks/pluginhooks.svelte.ts";
 import { syncProgressCtrl } from "../islands/syncprogress/syncprogress.svelte.ts";
@@ -3559,6 +3561,15 @@ async function closeRepo(){
 // whether or not a repo is currently open (the dashboard's own "+ Add
 // repository…" is where the native picker still lives).
 $(".repo-pick").addEventListener("click", ()=>dashboardCtrl.show());
+// Right-click the same chip for the repo-level actions. GitCat has no repo
+// tabs to hang these on (one repo per window, see src-tauri/src/windows.rs),
+// and this chip is the only thing in the UI that names the open repo.
+// repoMenuItems() returns nothing when no repo is open, and open([]) is a
+// no-op, so an empty chip right-clicks to nothing rather than to dead entries.
+$(".repo-pick").addEventListener("contextmenu", (e)=>{
+  e.preventDefault();
+  contextMenuCtrl.open(repoMenuItems(CUR_REPO), e.clientX, e.clientY);
+});
 
 // Persisted settings (Settings modal, src/islands/settings) — defaults match
 // what this boot sequence used to hardcode, so an existing user with nothing

--- a/src/legacy/paths.test.ts
+++ b/src/legacy/paths.test.ts
@@ -1,0 +1,42 @@
+// Tests for the repo-path join behind "Copy full path".
+import { describe, expect, it } from "vitest";
+
+import { joinRepoPath } from "./paths.ts";
+
+describe("joinRepoPath", () => {
+  // git always prints forward slashes, on every platform. A path pasted into
+  // Explorer's address bar or a PowerShell prompt should look native, so the
+  // separator comes from the REPO path — the one form we know the OS wrote.
+  it("uses backslashes for a Windows repo, and converts git's own slashes", () => {
+    expect(joinRepoPath("C:\\Users\\me\\proj", "src/main.rs")).toBe("C:\\Users\\me\\proj\\src\\main.rs");
+    expect(joinRepoPath("C:\\Users\\me\\proj", "README.md")).toBe("C:\\Users\\me\\proj\\README.md");
+  });
+
+  it("uses forward slashes for a unix repo", () => {
+    expect(joinRepoPath("/home/me/proj", "src/main.rs")).toBe("/home/me/proj/src/main.rs");
+  });
+
+  // A WSL repo is addressed from Windows as a UNC share, so it is a
+  // backslash path even though everything inside the distro is not.
+  it("treats a UNC/WSL repo as a backslash path", () => {
+    expect(joinRepoPath("\\\\wsl.localhost\\Ubuntu\\home\\me\\proj", "src/main.rs")).toBe(
+      "\\\\wsl.localhost\\Ubuntu\\home\\me\\proj\\src\\main.rs",
+    );
+  });
+
+  // Trailing separators turn up when a path is assembled elsewhere; a
+  // doubled one is ugly in a pasted path and wrong in some shells.
+  it("does not double a separator the repo path already ends with", () => {
+    expect(joinRepoPath("/home/me/proj/", "a.txt")).toBe("/home/me/proj/a.txt");
+    expect(joinRepoPath("C:\\proj\\", "a.txt")).toBe("C:\\proj\\a.txt");
+  });
+
+  // The menu is built from a row that always has a path, but the repo can be
+  // absent for one frame while a repo is being opened/closed. Returning the
+  // relative path is the least surprising thing to put on the clipboard —
+  // better than "undefined/src/main.rs".
+  it("falls back to the relative path when there is no repo", () => {
+    expect(joinRepoPath("", "src/main.rs")).toBe("src/main.rs");
+    expect(joinRepoPath(null as unknown as string, "src/main.rs")).toBe("src/main.rs");
+  });
+});

--- a/src/legacy/paths.ts
+++ b/src/legacy/paths.ts
@@ -1,0 +1,30 @@
+// Path joining for "Copy full path" — the one place the app turns git's own
+// repo-relative spelling into something a user can paste into a shell or a
+// file-manager address bar.
+//
+// The separator is taken from the REPO path rather than from the running
+// platform. Those agree most of the time, but not always: a WSL repo opened
+// from Windows is a `\\wsl.localhost\…` UNC path whose contents are a Linux
+// filesystem, and a path assembled from `navigator.platform` would get one of
+// the two halves wrong. The repo path is the one spelling we know the OS
+// itself produced.
+//
+// Leaf module — imports nothing.
+
+/**
+ * Join a repo-relative path (git's own form, always forward-slashed) onto its
+ * repo path, in the repo's own separator style.
+ *
+ * With no repo — possible for a frame while one is being opened or closed —
+ * the relative path is returned unchanged, which is a more useful thing to
+ * land on the clipboard than a path with `undefined` in it.
+ */
+export function joinRepoPath(repo: string, relative: string): string {
+  if (!repo) return relative;
+  const windowsish = repo.includes("\\");
+  const sep = windowsish ? "\\" : "/";
+  const base = repo.endsWith("\\") || repo.endsWith("/") ? repo.slice(0, -1) : repo;
+  // split/join rather than replaceAll: the tsconfig lib predates ES2021.
+  const rel = windowsish ? relative.split("/").join("\\") : relative;
+  return base + sep + rel;
+}

--- a/src/legacy/platform.test.ts
+++ b/src/legacy/platform.test.ts
@@ -1,0 +1,77 @@
+// Tests for the platform sniffer behind the reveal-in-file-manager label.
+//
+// Pure string work over a user-agent, so unlike its neighbours this leaf
+// needs no bridge/ipc mocking — it imports nothing.
+import { describe, expect, it } from "vitest";
+
+import { currentPlatform, openDirLabelKey, revealLabelKey } from "./platform.ts";
+
+// Real user-agent strings, as the webview reports them on each platform.
+// Chromium reports macOS as "Macintosh; Intel Mac OS X" even on Apple
+// silicon, so an arm64 Mac is NOT a separate case to handle here.
+const UA = {
+  windows:
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+  macIntel:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+  macArm:
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+  linux:
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+};
+
+describe("currentPlatform", () => {
+  it("recognizes the three desktop platforms GitCat ships on", () => {
+    expect(currentPlatform(UA.windows)).toBe("windows");
+    expect(currentPlatform(UA.macIntel)).toBe("macos");
+    expect(currentPlatform(UA.macArm)).toBe("macos");
+    expect(currentPlatform(UA.linux)).toBe("linux");
+  });
+
+  // Every non-Windows, non-Mac desktop this app can run on is a Linux-ish
+  // one, and the Linux label ("file manager") is the generic of the three —
+  // so an unrecognized UA landing there degrades to a still-true label
+  // rather than telling a Linux user about Explorer.
+  it("falls back to linux for anything it does not recognize", () => {
+    expect(currentPlatform("")).toBe("linux");
+    expect(currentPlatform("Mozilla/5.0 (X11; FreeBSD amd64)")).toBe("linux");
+    expect(currentPlatform("something else entirely")).toBe("linux");
+  });
+
+  // "Windows NT" must be matched before "Mac"/"Linux": a Windows UA contains
+  // neither, but this pins the order so a future edit can't reintroduce the
+  // classic bug where "X11; Linux" inside a spoofed Windows UA wins.
+  it("prefers Windows when a UA mentions more than one platform", () => {
+    expect(currentPlatform("Mozilla/5.0 (Windows NT 10.0) like Macintosh Linux")).toBe("windows");
+  });
+});
+
+describe("revealLabelKey", () => {
+  // The whole point of the platform sniff: Windows users read "File
+  // Explorer", Mac users read "Finder", and neither name is right for the
+  // other. Keys are returned whole (never assembled from a fragment) so a
+  // grep for the key finds this line.
+  it("maps each platform to its own label key", () => {
+    expect(revealLabelKey("windows")).toBe("common.reveal_windows");
+    expect(revealLabelKey("macos")).toBe("common.reveal_macos");
+    expect(revealLabelKey("linux")).toBe("common.reveal_linux");
+  });
+});
+
+describe("openDirLabelKey", () => {
+  // A repo and a file want different verbs even though they name the same
+  // application: a file gets REVEALED (its folder opens with the file
+  // selected), a repo gets OPENED (you land inside it). Two key families,
+  // not one — see the menus in Detail/Workdir vs the repo chip.
+  it("maps each platform to its own label key", () => {
+    expect(openDirLabelKey("windows")).toBe("common.open_dir_windows");
+    expect(openDirLabelKey("macos")).toBe("common.open_dir_macos");
+    expect(openDirLabelKey("linux")).toBe("common.open_dir_linux");
+  });
+
+  it("is a different key from the reveal one on every platform", () => {
+    for (const p of ["windows", "macos", "linux"] as const) {
+      expect(openDirLabelKey(p)).not.toBe(revealLabelKey(p));
+    }
+  });
+});

--- a/src/legacy/platform.ts
+++ b/src/legacy/platform.ts
@@ -1,0 +1,81 @@
+// Which desktop this window is running on, for the ONE place the app's copy
+// has to differ per platform: the name of the OS file manager.
+//
+// This is GitCat's first platform branch, and it is deliberately the only
+// one. Everything else in the UI is written once and reads the same
+// everywhere — the keyboard hints say ⌘ on Windows too. That is a defensible
+// house style for a shortcut glyph, but not for a proper noun: telling a Mac
+// user to look in "File Explorer", or a Windows user to look in "Finder",
+// names an application that isn't on their machine.
+//
+// The user agent, not a Tauri command: the webview already knows, so a sniff
+// here costs nothing, stays synchronous (menu labels are rendered during a
+// right-click, with no await to hang them on), and works identically in the
+// browser design mode where no Tauri backend exists at all.
+//
+// Leaf module — imports nothing, so it is safe for any island or for
+// legacy/main.ts to pull in.
+
+export type Platform = "windows" | "macos" | "linux";
+
+/// Every reveal label key, so a grep for any one of them lands here.
+export type RevealLabelKey = "common.reveal_windows" | "common.reveal_macos" | "common.reveal_linux";
+
+/// Every open-the-folder label key. Separate from `RevealLabelKey` because a
+/// file and a directory take different verbs — see `openDirLabelKey`.
+export type OpenDirLabelKey = "common.open_dir_windows" | "common.open_dir_macos" | "common.open_dir_linux";
+
+/**
+ * Classify the running platform from a user-agent string.
+ *
+ * The UA is a parameter (defaulting to the live one) purely so this is
+ * testable without a jsdom navigator stub.
+ *
+ * Windows is checked FIRST on purpose. A UA that mentions more than one
+ * platform is either spoofed or an embedded webview being creative, and
+ * "Windows NT" is the most specific of the three markers — checking "Linux"
+ * first would misfile an X11-mentioning Windows UA, which is the classic
+ * shape of this bug.
+ *
+ * Anything unrecognized is treated as Linux. That is not a guess about the
+ * OS, it is a choice about which of three labels is least wrong: "file
+ * manager" is the generic term, true on any desktop, whereas the other two
+ * name a specific application.
+ */
+export function currentPlatform(ua: string = typeof navigator === "undefined" ? "" : navigator.userAgent): Platform {
+  if (ua.includes("Windows NT") || ua.includes("Win64") || ua.includes("Win32")) return "windows";
+  // Chromium reports Apple silicon as "Intel Mac OS X" too, so this single
+  // check covers both Mac architectures — there is no arm64 special case.
+  if (ua.includes("Macintosh") || ua.includes("Mac OS X")) return "macos";
+  return "linux";
+}
+
+/**
+ * The i18n key for "reveal this in the OS file manager" on `platform`.
+ *
+ * Returns whole keys rather than assembling `"common.reveal_" + platform`:
+ * a constructed key is invisible to a grep for the key, which is how a
+ * locale entry gets deleted as unused and the UI quietly falls back to
+ * printing the key itself.
+ */
+export function revealLabelKey(platform: Platform = currentPlatform()): RevealLabelKey {
+  if (platform === "windows") return "common.reveal_windows";
+  if (platform === "macos") return "common.reveal_macos";
+  return "common.reveal_linux";
+}
+
+/**
+ * The i18n key for "open this directory in the OS file manager".
+ *
+ * A separate family from [`revealLabelKey`] because the two actions differ,
+ * not just their subject: revealing a FILE opens its containing folder with
+ * the file selected, while a repo is a folder you want to land INSIDE. The
+ * backend calls differ to match (`revealItemInDir` vs `openPath`), so the
+ * labels have to as well — "Show in Finder" would be a lie about where the
+ * repo menu takes you.
+ */
+export function openDirLabelKey(platform: Platform = currentPlatform()): OpenDirLabelKey {
+  if (platform === "windows") return "common.open_dir_windows";
+  if (platform === "macos") return "common.open_dir_macos";
+  return "common.open_dir_linux";
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,13 @@ import { IN_TAURI } from "./ipc/env";
 import * as bridge from "./legacy/bridge";
 import { dlog } from "./devlog";
 import { commands } from "./ipc/bindings";
+import ContextMenu from "./islands/contextmenu/ContextMenu.svelte";
 
+// Shared right-click menu. Mounted first because every other island can
+// open it, and it renders nothing until one does. Surfaces call
+// contextMenuCtrl.open(items, x, y) from their own oncontextmenu handler
+// rather than each rendering a popover of their own.
+mount(ContextMenu, { target: document.body });
 mount(Resolver, { target: document.body });
 mount(CommitMenu, { target: document.body });
 mount(Bisect, { target: document.body });


### PR DESCRIPTION
Right-click a file, a folder, or the repo name in the topbar, and get a menu.

Rebased onto `dev`, so the diff is this branch's own commits rather than the stack it used to carry.

## Demo

https://github.com/user-attachments/assets/0bd63156-3b9d-468c-bccb-9d37e4762797

Recorded on Windows: the menus on a file row, a folder row and the repo chip, and where each of the file-manager actions actually lands.

## What you get

| Where | Items |
|---|---|
| A commit's changed file | Blame · History · External diff · — · Show in \<file manager\> · Copy path · Copy full path |
| A commit's folder | Open in \<file manager\> · Copy path · Copy full path |
| A working-tree file, unstaged | Stage · Discard · — · Show in \<file manager\> · Copy path · Copy full path |
| A working-tree file, staged | Unstage · — · Show in \<file manager\> · Copy path · Copy full path |
| A working-tree folder | Stage/Unstage folder · — · Open in \<file manager\> · Copy path · Copy full path |
| The topbar repo chip | Terminal · Open in \<file manager\> · Copy path |

Each surface's menu carries the actions that surface already shows as icon buttons, then the path items. A menu offering *less* than the visible buttons is a strange thing to discover. Working-tree folders get no Discard — the button row has none either, and a typed-confirm scrim naming a whole directory is a much larger decision than discarding one file. Neither do staged rows: a staged row's discard would act on the worktree, which either fails outright or throws away the unstaged edits and leaves the staged change alone.

## One menu, not a fourth one

Workdir already had a hand-rolled right-click popover, and Sidebar a second. Two more surfaces would have meant four places to fix the next positioning or dismissal bug in, so this adds one shared island (`src/islands/contextmenu/`) that owns the backdrop, Escape/scroll/resize dismissal, and closing before an item runs — several of these actions open a dialog whose first click the backdrop would otherwise swallow.

Workdir's popover is migrated onto it and its markup deleted. **Sidebar's menus are deliberately left alone** — they are unrelated to this change, and rewriting working code for tidiness is how you get a regression you cannot explain.

The shared menu also flips away from the viewport edge rather than clamping. The commit file list sits at the bottom of the window; a six-item menu opening downward from there ran off the fold, and with the backdrop swallowing scroll those items were simply unreachable.

## Why reveal and open go through Rust

`@tauri-apps/plugin-opener` ships JS bindings for both, and `revealItemInDir` is already allowed by this app's `opener:default` capability. The **open** half is the problem: it needs `allow-open-path`, whose scope check (`scope.rs`'s `is_path_allowed`) ends in `self.allowed.iter().any(...)` — false for an empty allow list. So the capability would have to carry one, and the only list broad enough for "whichever repo the user has open" is `**`.

That grants the webview the right to ask the OS to open **any** path with its default application, and this app runs third-party plugin code in that webview (`plugin_exec.rs`). Both actions live in `file_manager.rs` instead, behind `trust::open_repo` — the same gate `terminal.rs` uses for the considerably more powerful shell it spawns.

The commands take the repo path and the file's repo-relative path separately, and join them server-side with a containment check. Callers pass paths from this app's own file lists, so a traversal would be a bug rather than an attack — but the check is two lines and the failure it prevents is the kind that is embarrassing to explain afterwards.

## The one platform branch

`legacy/platform.ts` is this app's first place where copy varies by OS, and is meant to stay the only one. Everything else is written once — the keyboard hints say ⌘ on Windows too. That is a defensible house style for a shortcut glyph, but not for a proper noun: telling a Mac user to look in "File Explorer" names an application that is not on their machine.

Sniffed from the user agent rather than asked of the backend, so it stays synchronous (menu labels render during a right-click, with no await to hang them on) and works in browser design mode where there is no backend at all. Anything unrecognized gets "file manager", which is true on any desktop.

**Two verbs, deliberately.** A file is *revealed* — its folder opens with the file selected. A folder is *opened* — you land inside it. The backend calls differ to match (`reveal_item_in_dir` vs `open_path`), so "Show in Finder" on a folder would be a lie about where it takes you.

That is why folder rows get their own item builder rather than reusing the file one, and why `open_repo_in_file_manager(repo)` is generalized here to `open_dir_in_file_manager(repo, relative)` — an empty `relative` means the repo itself. The topbar chip and a folder row then go through one command instead of two that would have to be kept in step.

One rendering rule came with it: `ContextMenu.svelte` now drops a `separatorBefore` on the *first* item. The shared builders mark their group break on their own first entry, which is right when a surface stacks its actions above them and a stray top border when it does not — exactly a commit tree's folder rows, where the path items are the whole menu.

## One thing found while wiring this up

The two plugin calls disagree about the Windows extended-length `\\?\C:\…` form. `reveal_item_in_dir` runs its argument through `dunce::simplified`, which drops the prefix; `open_path` only stats the path — which succeeds, that being exactly what the prefix is for — and then hands it to `ShellExecute`, which does not understand it. Same input, one works and one does not.

Nothing upstream produces that form any more: `repo_registry::normalize` and the `gitcat .` argument classifier both strip it. So `file_manager.rs` holds the invariant where it is relied on rather than trusting every caller, in one no-op-everywhere helper with a test.

## What I checked

| | |
|---|---|
| svelte-check | 0 errors |
| vitest | 1515 passed |
| Playwright | 50 passed |
| Rust suite | 723 passed, 0 failed |
| `src/ipc/bindings.ts` | regenerated by `cargo test export_bindings` — identical to what is committed |

47 new unit tests cover the platform sniffer, the path join, the menu controller and the two shared item builders, plus the reworked Workdir menu tests — including the two that pin the staged-row and deleted-file rules from your review. Four Playwright specs cover opening a file menu and a folder menu, edge-flipping, and dismissal in a real browser — the folder one also pins that a right-click does not toggle the `<details>` open. `file_manager.rs` has eight, including the traversal shapes the join refuses and the empty relative the repo chip relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


