### PR TITLE
Add a minGitcatVersion gate to the plugin manifest

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -56,6 +56,7 @@ A manifest is a small JSON document. Here's a complete, annotated example:
 | `id` | ✅ | string | Stable, unique identifier. Must match `^[a-z0-9][a-z0-9-]*$` — start with a lowercase letter or digit, then lowercase letters, digits, and `-` only. No uppercase, spaces, underscores, or dots. Used as the enable/remove key. Installing a second plugin with the same `id` is rejected. |
 | `name` | ✅ | string | Human-readable display name (shown in Settings and as the ⌘K hint). Must be non-empty. |
 | `version` | ✅ | string | Any non-empty string (e.g. `"1.0.0"`). Not parsed or compared — it's just for your reference. |
+| `minGitcatVersion` | — | string | The oldest GitCat that can run this plugin, e.g. `"1.3.0"` (`"1.3"` works too — a missing component reads as zero). Omit it and the plugin installs on any host. See [Requiring a GitCat version](#requiring-a-gitcat-version). |
 | `description` | — | string | Optional one-liner. |
 | `enabled` | — | boolean | Defaults to `true` when omitted — a freshly installed plugin is active until you disable it. |
 | `commands` | — | array | Zero or more [commands](#commands). Defaults to `[]`. |
@@ -64,6 +65,34 @@ A manifest is a small JSON document. Here's a complete, annotated example:
 | `lua` | — | string | Optional path (relative to the plugin folder) to a main Luau script — required only if any command/hook uses a `handler`. See [Scripting with Luau](#scripting-with-luau). |
 
 A manifest must be a regular file no larger than **256 KB** (a `plugin.json` is tiny by design).
+
+### Requiring a GitCat version
+
+<a id="requiring-a-gitcat-version"></a>
+
+If your plugin uses something a newer GitCat introduced — a placeholder token, a
+widget type, a manifest field — say so with `minGitcatVersion`:
+
+```json
+{ "id": "my-plugin", "name": "My Plugin", "version": "1.0.0", "minGitcatVersion": "1.3.0" }
+```
+
+An older host then **refuses the install** with a message naming both versions,
+instead of accepting the plugin and misbehaving later.
+
+That "misbehaving later" is worth being concrete about, because it is quiet. An
+unrecognized placeholder token expands to the **empty string**, so a `run` of
+`rm {file}` written against a GitCat that has `{file}` becomes plain `rm` on one
+that doesn't. Nothing errors, nothing warns; the command simply runs with your
+argument deleted. Declaring the floor is what turns that into a refusal at the
+one moment a person is present to read it.
+
+**One honest limitation.** The gate only protects hosts that have the gate.
+GitCat 1.2 and earlier ignore `minGitcatVersion` entirely, so the first
+generation of gated plugins still installs silently on them. That is
+unavoidable — an older release cannot be taught to read a field that did not
+exist when it shipped — and it is not a reason to leave the field out. Every
+host from 1.3 on honours it.
 
 ## Commands
 

--- a/src-tauri/src/plugin_registry.rs
+++ b/src-tauri/src/plugin_registry.rs
@@ -287,6 +287,25 @@ pub struct Plugin {
     pub id: String,
     pub name: String,
     pub version: String,
+    /// The OLDEST GitCat that can run this plugin — `"1.3.0"`, or `"1.3"` (a
+    /// missing component reads as zero). Absent means "any host", which is
+    /// every manifest written before this field existed.
+    ///
+    /// This exists because of one specific, quiet failure mode:
+    /// [`plugin_exec::substitute`](crate::plugin_exec) expands an UNRECOGNIZED
+    /// placeholder token to the EMPTY STRING. So a plugin authored against a
+    /// newer GitCat does not fail loudly on an older host — a `run` of
+    /// `rm {file}` simply becomes `rm`. Declaring the floor turns that into a
+    /// refusal at install time, which is the only point where the user is
+    /// present to read it.
+    ///
+    /// Honest limitation, also stated in `docs/plugins.md`: the gate only
+    /// protects hosts that HAVE the gate. GitCat 1.2 and earlier ignore this
+    /// field entirely, so the first generation of gated plugins still installs
+    /// silently onto them. Unavoidable, and not a reason to skip it — every
+    /// host from here on is covered.
+    #[serde(default)]
+    pub min_gitcat_version: Option<String>,
     pub description: Option<String>,
     /// Defaults to `true` when a manifest omits it — a freshly installed
     /// plugin is active unless the user disables it.
@@ -457,6 +476,16 @@ pub fn validate_manifest(plugin: &Plugin) -> Result<(), String> {
     }
     if plugin.version.trim().is_empty() {
         return Err(ierr("err_plugins.missing_version"));
+    }
+    // SYNTAX only. Whether THIS host satisfies the floor is decided at install
+    // time by `read_and_validate_manifest`, before the manifest is even fully
+    // parsed — see the probe there for why the order matters. Here we only
+    // refuse a value that is not a version at all, so a typo can never be read
+    // as "no floor declared".
+    if let Some(min) = plugin.min_gitcat_version.as_deref() {
+        if crate::version::parse(min).is_none() {
+            return Err(ierrp("err_plugins.min_version_invalid", &[("value", &format!("{min:?}"))]));
+        }
     }
     // Each command/hook must declare EXACTLY ONE of a non-empty shell `run` or a
     // non-empty Luau `handler` (PER-56) — never neither, never both. A `handler`
@@ -642,6 +671,46 @@ pub fn read_and_validate_manifest(source: &Path) -> Result<Plugin, String> {
             &[("path", &manifest.display().to_string()), ("limit", &MAX_MANIFEST_BYTES.to_string())],
         ));
     }
+    // ── The version gate runs FIRST, off a probe, and deliberately so ───────
+    //
+    // The gate exists to tell a user "this plugin needs GitCat 1.4 or newer"
+    // instead of letting a newer manifest run here with its unknown tokens
+    // silently expanding to nothing. That message is only reachable if the
+    // version is read BEFORE anything else can reject the manifest for being
+    // written against a newer GitCat.
+    //
+    // Today's `Plugin` parse is permissive (serde ignores unknown fields), so
+    // ordering looks academic. It stops being academic the moment strict
+    // parsing lands (#64): `deny_unknown_fields` would have serde reject a
+    // manifest carrying a field this host has never heard of, and the user
+    // would get `unknown field "foo"` instead of the version message that
+    // actually explains what to do about it. Probing one field first is what
+    // keeps that from happening — do not fold this back into the main parse.
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct VersionProbe {
+        min_gitcat_version: Option<String>,
+    }
+    let probe: VersionProbe = serde_json::from_str(&text).map_err(|e| {
+        ierrp("err_plugins.manifest_invalid", &[("path", &manifest.display().to_string()), ("detail", &e.to_string())])
+    })?;
+    if let Some(required) = probe.min_gitcat_version.as_deref() {
+        match crate::version::host_meets(required) {
+            // An unreadable floor is a manifest error, never a silent pass —
+            // see version::host_meets.
+            None => {
+                return Err(ierrp("err_plugins.min_version_invalid", &[("value", &format!("{required:?}"))]))
+            }
+            Some(false) => {
+                return Err(ierrp(
+                    "err_plugins.needs_newer_gitcat",
+                    &[("required", required), ("host", crate::version::HOST_VERSION)],
+                ))
+            }
+            Some(true) => {}
+        }
+    }
+
     let mut plugin: Plugin = serde_json::from_str(&text).map_err(|e| {
         ierrp("err_plugins.manifest_invalid", &[("path", &manifest.display().to_string()), ("detail", &e.to_string())])
     })?;
@@ -1067,6 +1136,7 @@ mod tests {
             id: id.to_string(),
             name: "Sample".into(),
             version: "1.0.0".into(),
+            min_gitcat_version: None,
             description: Some("a test plugin".into()),
             enabled: true,
             commands: vec![PluginCommand {
@@ -1272,6 +1342,102 @@ mod tests {
         assert_eq!(installed.id, "frompath");
         assert_eq!(installed.version, "2.0.0");
 
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -- minGitcatVersion gate (#63) -----------------------------------------
+
+    /// Write a manifest carrying `min` (or none) and try to install it.
+    fn install_with_min(tag: &str, min: Option<&str>) -> Result<Plugin, String> {
+        let dir = temp_dir(tag);
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = dir.join("plugin.json");
+        let field = min.map(|m| format!(r#","minGitcatVersion":"{m}""#)).unwrap_or_default();
+        std::fs::write(&manifest, format!(r#"{{"id":"gated","name":"Gated","version":"1.0.0"{field}}}"#)).unwrap();
+        let out = read_and_validate_manifest(&manifest);
+        let _ = std::fs::remove_dir_all(&dir);
+        out
+    }
+
+    #[test]
+    fn a_floor_this_host_meets_installs_and_survives_a_round_trip() {
+        let plugin = install_with_min("min-ok", Some(crate::version::HOST_VERSION))
+            .expect("a plugin whose floor is exactly this host must install");
+        assert_eq!(plugin.min_gitcat_version.as_deref(), Some(crate::version::HOST_VERSION));
+
+        install_with_min("min-old", Some("0.0.1")).expect("an ancient floor must install");
+        let none = install_with_min("min-absent", None).expect("no floor at all must install");
+        assert_eq!(none.min_gitcat_version, None, "absent must stay absent, not become an empty string");
+
+        // The field has to survive the registry file, or the gate would silently
+        // vanish from every plugin the moment it was saved.
+        let dir = temp_dir("min-roundtrip");
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = dir.join(FILE_NAME);
+        let mut p = sample_plugin("gated");
+        p.min_gitcat_version = Some("1.3".into());
+        save_to(&store, &[p]).unwrap();
+        let loaded = load_from(&store).unwrap();
+        assert_eq!(loaded[0].min_gitcat_version.as_deref(), Some("1.3"), "minGitcatVersion must round-trip");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_floor_above_this_host_is_refused_with_both_versions_in_the_message() {
+        let (major, _, _) = crate::version::parse(crate::version::HOST_VERSION).unwrap();
+        let too_new = format!("{}.0.0", major + 1);
+        let err = install_with_min("min-too-new", Some(&too_new)).expect_err("a newer floor must be refused");
+        assert!(err.contains("err_plugins.needs_newer_gitcat"), "got: {err}");
+        // Both numbers travel with the error: the user needs to know what the
+        // plugin wants AND what they have, or the message is unactionable.
+        assert!(err.contains(&too_new), "the required version must be in the error: {err}");
+        assert!(err.contains(crate::version::HOST_VERSION), "the host version must be in the error: {err}");
+    }
+
+    #[test]
+    fn an_unreadable_floor_is_a_manifest_error_never_a_silent_pass() {
+        // The dangerous outcome is not "wrongly refused", it is "wrongly
+        // admitted": a typo that reads as `no floor declared` puts us back to
+        // the silent empty-string expansion this gate exists to stop.
+        for bad in ["banana", "", "1.2.3.4", "v1.2.3"] {
+            let err = install_with_min("min-bad", Some(bad))
+                .expect_err("an unreadable minGitcatVersion must be refused, not ignored");
+            assert!(err.contains("err_plugins.min_version_invalid"), "{bad:?} got: {err}");
+        }
+        // validate_manifest rejects the same value on its own, so the check does
+        // not depend on going through the install path.
+        let mut p = sample_plugin("gated");
+        p.min_gitcat_version = Some("banana".into());
+        assert!(validate_manifest(&p).unwrap_err().contains("err_plugins.min_version_invalid"));
+        p.min_gitcat_version = Some("1.3".into());
+        assert!(validate_manifest(&p).is_ok(), "a readable floor must validate");
+    }
+
+    #[test]
+    fn the_version_gate_reports_before_any_other_manifest_complaint() {
+        // The ordering this whole design turns on. This manifest is ALSO invalid
+        // for an unrelated reason (an id with a space), and the version message
+        // still wins — because the probe runs before the full parse and before
+        // validate_manifest. When strict parsing lands (#64) it is this ordering
+        // that keeps a 1.4-authored manifest from reporting `unknown field` on a
+        // 1.3 host instead of "you need a newer GitCat".
+        let (major, _, _) = crate::version::parse(crate::version::HOST_VERSION).unwrap();
+        let dir = temp_dir("min-order");
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = dir.join("plugin.json");
+        std::fs::write(
+            &manifest,
+            format!(
+                r#"{{"id":"NOT A VALID ID","name":"","version":"","minGitcatVersion":"{}.0.0"}}"#,
+                major + 1
+            ),
+        )
+        .unwrap();
+        let err = read_and_validate_manifest(&manifest).expect_err("must be refused");
+        assert!(
+            err.contains("err_plugins.needs_newer_gitcat"),
+            "the version gate must win over id/name/version validation; got: {err}"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/version.rs
+++ b/src-tauri/src/version.rs
@@ -35,9 +35,62 @@
 /// structure — parse it where you need to order two versions.
 pub const HOST_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// A version reduced to the three numbers that order it.
+pub type Version = (u64, u64, u64);
+
+/// Parse `major[.minor[.patch]]` into the triple that orders it, or `None` if
+/// the string is not a version at all.
+///
+/// Two deliberate leniencies, both in the direction of accepting what an author
+/// obviously meant:
+///
+/// * A missing component reads as zero, so `"1.3"` is `1.3.0`. A plugin author
+///   writing the two-component form means the 1.3 line, and refusing it would
+///   be pedantry with an install error attached.
+/// * A `-prerelease` or `+build` suffix is DROPPED before parsing. Nightly
+///   builds carry one (`1.3.0-nightly.4`), and a plugin asking for 1.3.0 wants
+///   the feature set, not a particular build of it. The corollary is that a
+///   nightly counts as its base version, which is the answer that makes a
+///   nightly useful for testing plugins.
+///
+/// Anything else — empty, non-numeric, more than three components, a component
+/// that overflows `u64` — is `None`, and callers turn that into a manifest
+/// error rather than guessing.
+pub fn parse(v: &str) -> Option<Version> {
+    let core = v.trim();
+    let core = core.split(['-', '+']).next()?;
+    if core.is_empty() {
+        return None;
+    }
+    let mut parts = core.split('.');
+    let mut out = [0u64; 3];
+    for slot in out.iter_mut() {
+        match parts.next() {
+            None => break,
+            Some(p) => *slot = p.parse().ok()?,
+        }
+    }
+    if parts.next().is_some() {
+        return None; // four or more components is not a version we understand
+    }
+    Some((out[0], out[1], out[2]))
+}
+
+/// Is this host at least `required`?
+///
+/// `None` means `required` is not parseable as a version — the caller's job is
+/// to report that as a bad manifest, NOT to fall back to allowing the install.
+/// Silently admitting a plugin whose floor we could not read is exactly the
+/// failure mode this whole mechanism exists to prevent.
+pub fn host_meets(required: &str) -> Option<bool> {
+    let required = parse(required)?;
+    let host = parse(HOST_VERSION).expect("HOST_VERSION comes from Cargo.toml and always parses");
+    Some(host >= required)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::HOST_VERSION;
+    use super::{host_meets, parse, HOST_VERSION};
     use std::path::PathBuf;
 
     /// The repository root: the parent of `src-tauri/`, which is what Cargo
@@ -105,6 +158,42 @@ mod tests {
         text.lines()
             .find_map(|line| quoted_value(line, "version"))
             .unwrap_or_else(|| panic!("nix/package.nix has no `version = \"…\";` attribute"))
+    }
+
+    #[test]
+    fn parse_accepts_the_forms_a_manifest_author_actually_writes() {
+        assert_eq!(parse("1.3.0"), Some((1, 3, 0)));
+        assert_eq!(parse("1.3"), Some((1, 3, 0)), "a missing component reads as zero");
+        assert_eq!(parse("2"), Some((2, 0, 0)));
+        assert_eq!(parse(" 1.3.0 "), Some((1, 3, 0)), "surrounding whitespace is not a syntax error");
+        assert_eq!(parse("1.3.0-nightly.4"), Some((1, 3, 0)), "a prerelease counts as its base version");
+        assert_eq!(parse("1.3.0+build7"), Some((1, 3, 0)), "build metadata is dropped");
+        assert_eq!(parse("10.0.0"), Some((10, 0, 0)), "components are numbers, not characters");
+    }
+
+    #[test]
+    fn parse_rejects_what_is_not_a_version() {
+        for bad in ["", "   ", "banana", "1.x", "1.3.0.1", "v1.3.0", "1..0", "-1.0.0", "1.3.-0"] {
+            assert_eq!(parse(bad), None, "{bad:?} must not parse as a version");
+        }
+    }
+
+    #[test]
+    fn parse_orders_by_number_not_by_string() {
+        // The whole reason this is a triple and not a string compare: "10" < "9"
+        // lexicographically, and a plugin floor of 1.9.0 must not lock out 1.10.0.
+        assert!(parse("1.10.0") > parse("1.9.0"));
+        assert!(parse("2.0.0") > parse("1.99.99"));
+    }
+
+    #[test]
+    fn host_meets_compares_against_this_build_and_reports_an_unreadable_floor() {
+        let (maj, min, patch) = parse(HOST_VERSION).expect("the host version must parse");
+        assert_eq!(host_meets(HOST_VERSION), Some(true), "a host always meets its own version");
+        assert_eq!(host_meets(&format!("{maj}.{min}.{patch}")), Some(true));
+        assert_eq!(host_meets(&format!("{}.0.0", maj + 1)), Some(false), "a newer major is not met");
+        assert_eq!(host_meets("0.0.1"), Some(true), "an ancient floor is met");
+        assert_eq!(host_meets("banana"), None, "an unreadable floor is None, never a silent yes");
     }
 
     /// The whole point of this module. `src-tauri/Cargo.toml` is authoritative

--- a/src/i18n/locales/en/err_plugins.ts
+++ b/src/i18n/locales/en/err_plugins.ts
@@ -17,6 +17,9 @@ export default {
     "Plugin id {id} is invalid — it must start with a lowercase letter or digit and then contain only lowercase letters, digits, and '-'.",
   missing_name: "Plugin manifest is missing a non-empty name.",
   missing_version: "Plugin manifest is missing a non-empty version.",
+  needs_newer_gitcat: "This plugin needs GitCat {required} or newer — this copy is {host}. Update GitCat, then install it again.",
+  min_version_invalid:
+    "Plugin manifest has an unreadable minGitcatVersion {value} — it must look like \"1.3.0\".",
   cmd_exactly_one_both:
     "Plugin command {id} must declare exactly one of a non-empty `run` (shell) or a non-empty `handler` (Luau) — it declares both.",
   cmd_exactly_one_neither:

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -4030,7 +4030,27 @@ export type Plugin = {
  * [`is_valid_id`]). Unique within the registry; used as the remove/enable
  * key and half of a command's `(pluginId, commandId)` address.
  */
-id: string; name: string; version: string; description: string | null; 
+id: string; name: string; version: string; 
+/**
+ * The OLDEST GitCat that can run this plugin — `"1.3.0"`, or `"1.3"` (a
+ * missing component reads as zero). Absent means "any host", which is
+ * every manifest written before this field existed.
+ * 
+ * This exists because of one specific, quiet failure mode:
+ * [`plugin_exec::substitute`](crate::plugin_exec) expands an UNRECOGNIZED
+ * placeholder token to the EMPTY STRING. So a plugin authored against a
+ * newer GitCat does not fail loudly on an older host — a `run` of
+ * `rm {file}` simply becomes `rm`. Declaring the floor turns that into a
+ * refusal at install time, which is the only point where the user is
+ * present to read it.
+ * 
+ * Honest limitation, also stated in `docs/plugins.md`: the gate only
+ * protects hosts that HAVE the gate. GitCat 1.2 and earlier ignore this
+ * field entirely, so the first generation of gated plugins still installs
+ * silently onto them. Unavoidable, and not a reason to skip it — every
+ * host from here on is covered.
+ */
+minGitcatVersion?: string | null; description: string | null; 
 /**
  * Defaults to `true` when a manifest omits it — a freshly installed
  * plugin is active unless the user disables it.


### PR DESCRIPTION
Part 2 of 3. **Stacked on #115** — review that one first; this PR's diff shows only its own commit once the base merges.

`#65 → #63 → #76`

## What

A plugin can declare `minGitcatVersion`, and an older host refuses the install with a message naming both versions.

```json
{ "id": "my-plugin", "name": "My Plugin", "version": "1.0.0", "minGitcatVersion": "1.3.0" }
```

## Why this matters more than a compatibility field usually would

The failure it prevents is silent. `plugin_exec.rs`'s `substitute()` expands an **unrecognized placeholder token to the empty string**, so a plugin authored against a newer GitCat does not fail loudly on an older host — a `run` of `rm {file}` simply becomes `rm`. Nothing errors, nothing warns, the argument is just gone.

That is why this has to land before any new placeholder token ships. `{file}` is the next PR in this stack.

## The ordering is the design

The gate runs off a one-field **probe** parse, before the full `Plugin` parse and before `validate_manifest`. Today's parse is permissive, so that looks academic. It stops being academic when strict parsing lands (#64): `deny_unknown_fields` would have serde reject a manifest carrying a newer field *before* any version check could run, and the user would get `unknown field "foo"` instead of the message that tells them what to do about it.

A test pins it — a manifest that is both too new **and** has an invalid id must report the version error.

## Decisions worth a second opinion

- **An unreadable floor is a manifest error, never a silent pass.** Admitting a plugin whose floor we could not read puts us straight back to the empty-string expansion this exists to stop.
- **Parsing is lenient in the author's favour**: `"1.3"` means 1.3.0, and a `-prerelease`/`+build` suffix is dropped, so a nightly counts as its base version and can test gated plugins. Comparison is numeric, so a 1.9.0 floor does not lock out 1.10.0.
- **The honest limitation**, stated in the docs and the field's doc comment: the gate only protects hosts that have the gate. GitCat 1.2 and earlier ignore `minGitcatVersion` entirely, so the first generation of gated plugins still installs silently onto them. Unavoidable, and not a reason to skip it.

## Checks

`bindings.ts` regenerated with `cargo test export_bindings`, not hand-edited. 295 lib tests pass (9 new). `pnpm check` clean.

Closes #63.
