### PR TITLE
Populate {file} in the plugin command context

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -116,7 +116,7 @@ Each entry in `commands[]` contributes one invocable action.
 | --- | --- |
 | `none` *(default)* | Always applicable; needs no selection. |
 | `commit` | Needs a selected commit (fills `{sha}`). |
-| `file` | Needs a selected file. |
+| `file` | Needs a selected file (fills `{file}`). With nothing selected the command is **not run** — GitCat says so rather than expanding `{file}` to nothing. |
 | `repo` | Repo-scoped — needs only the open repository. |
 
 > **What's populated today.** The built-in ⌘K invocation always fills `{repo}`, and fills `{sha}` for a `commit`-context command. The other tokens are recognized by the expander and reserved for richer selection contexts, but are not yet populated from the palette, so they currently expand to an empty string. Write your templates against the full grammar; just know that `file`/`files`/`diff`/`branch`/`ref` come from the UI later.
@@ -141,11 +141,18 @@ A `run` string is a template. Before running it, GitCat substitutes `{...}` toke
 | --- | --- |
 | `{repo}` | The repository's path. **Also the working directory** the command runs in. |
 | `{sha}` | The selected commit's id. |
-| `{file}` | A single selected file path. |
+| `{file}` | The selected file, relative to the repository root. Filled for a `file`-context command. |
 | `{files}` | Several selected file paths, each quoted, space-joined. |
 | `{diff}` | Diff text. |
 | `{branch}` | A branch name. |
 | `{ref}` | A full ref / tag / symbolic ref. |
+
+**Which tokens are filled today.** `{repo}` always; `{sha}` for a `commit`
+command; `{file}` for a `file` command. `{files}`, `{diff}`, `{branch}` and
+`{ref}` are recognized by the expander but nothing fills them yet, so they
+currently expand to nothing — write your `run` against the three above, and get
+the rest from git itself (your command runs with the repository as its working
+directory, so `git branch --show-current` and friends are right there).
 
 Rules the expander follows:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -141,7 +141,7 @@ A `run` string is a template. Before running it, GitCat substitutes `{...}` toke
 | --- | --- |
 | `{repo}` | The repository's path. **Also the working directory** the command runs in. |
 | `{sha}` | The selected commit's id. |
-| `{file}` | The selected file, relative to the repository root. Filled for a `file`-context command. |
+| `{file}` | The selected file, relative to the repository root. Filled for a `file`-context command, from whichever view is open — the working tree's selection when Uncommitted changes is showing, the commit's otherwise. |
 | `{files}` | Several selected file paths, each quoted, space-joined. |
 | `{diff}` | Diff text. |
 | `{branch}` | A branch name. |

--- a/src/i18n/locales/en/plugincommands.ts
+++ b/src/i18n/locales/en/plugincommands.ts
@@ -1,6 +1,7 @@
 // Plugin command (⌘K palette) strings. Keys become `plugincommands.<key>`.
 export default {
   open_repo_first: "Open a repository first to run a plugin command.",
+  select_file_first: "Select a file first — this plugin command needs one.",
   hint: "Plugin · {name}",
   demo_run: "This is where the plugin command would run (demo).",
   err_failed: "Plugin command failed.",

--- a/src/islands/plugincommands/plugincommands.svelte.test.ts
+++ b/src/islands/plugincommands/plugincommands.svelte.test.ts
@@ -26,9 +26,16 @@ vi.mock("../../ipc/bindings", () => ({
 // mock it so the real (non-demo) branches run.
 vi.mock("../../ipc/env", () => ({ IN_TAURI: true }));
 
+// The detail island owns the file selection `{file}` is filled from (#76).
+// Mocked for the same reason bridge is: importing the real one drags in the
+// resolver/blame/filehistory/externaltools graph this controller has no
+// business booting.
+vi.mock("../detail/detail.svelte.ts", () => ({ detailCtrl: { selectedFile: null as string | null } }));
+
 import { commands } from "../../ipc/bindings";
 import * as bridge from "../../legacy/bridge";
 import type { CommandOutput, Plugin } from "../../ipc/bindings";
+import { detailCtrl } from "../detail/detail.svelte.ts";
 import { parseTamaReaction, pluginCommandsCtrl } from "./plugincommands.svelte.ts";
 
 function ok<T>(data: T): { status: "ok"; data: T } {
@@ -52,6 +59,7 @@ function resetCtrl() {
   pluginCommandsCtrl.onActionsChanged = null;
   (bridge.state as unknown as { selectedRow: number }).selectedRow = -1;
   (bridge.BACKEND as unknown as { rows: Array<{ sha: string }> }).rows = [];
+  detailCtrl.selectedFile = null;
 }
 
 beforeEach(() => {
@@ -407,5 +415,84 @@ describe("invoke — missing repo", () => {
 
     expect(bridgeNull.tama.warn).toHaveBeenCalled();
     expect(bindingsNull.commands.runPluginCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe("invoke — the `file` context fills {file} (#76)", () => {
+  // A `file` command placed in the MENU, not the palette: build() drops it from
+  // the action list, but a panel button can still name it, so the context index
+  // has to carry it. That is what the "ids only" test below leans on.
+  const acme = plugin({
+    id: "acme",
+    name: "Acme",
+    commands: [
+      { id: "lint", label: "Lint this file", run: "lint {file}", handler: null, context: "file", placement: "palette", mutates: false },
+      { id: "count", label: "Count lines", run: "wc -l {file}", handler: null, context: "file", placement: "menu", mutates: false },
+    ],
+  });
+
+  it("sends the file the detail island has selected", async () => {
+    detailCtrl.selectedFile = "src/legacy/main.ts";
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({ stdout: "clean", success: true })));
+
+    await pluginCommandsCtrl.invoke("acme", "lint", "file");
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith(
+      "acme",
+      "lint",
+      expect.objectContaining({ repo: "/repo", file: "src/legacy/main.ts" }),
+    );
+  });
+
+  it("REFUSES to run when no file is selected, rather than expanding {file} to nothing", async () => {
+    // The behaviour this whole guard exists for: an unfilled token expands to
+    // the empty string, so `rm -rf {repo}/{file}` would become `rm -rf /repo/`.
+    detailCtrl.selectedFile = null;
+
+    await pluginCommandsCtrl.invoke("acme", "lint", "file");
+
+    expect(commands.runPluginCommand).not.toHaveBeenCalled();
+    expect(bridge.tama.warn).toHaveBeenCalled();
+  });
+
+  it("resolves the context from the manifest when the caller has only ids (panel buttons)", async () => {
+    // pluginpanels' runButton knows a plugin id and a command id and nothing
+    // else. Without the index it would fall through to "none" and send no file.
+    vi.mocked(commands.listPlugins).mockResolvedValueOnce(ok([acme]));
+    await pluginCommandsCtrl.ensureLoaded();
+    detailCtrl.selectedFile = "README.md";
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({ stdout: "12", success: true })));
+
+    await pluginCommandsCtrl.invoke("acme", "count");
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith(
+      "acme",
+      "count",
+      expect.objectContaining({ file: "README.md" }),
+    );
+  });
+
+  it("a disabled plugin's commands are not in the context index", async () => {
+    vi.mocked(commands.listPlugins).mockResolvedValueOnce(ok([plugin({ ...acme, enabled: false })]));
+    await pluginCommandsCtrl.ensureLoaded();
+    detailCtrl.selectedFile = "README.md";
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({ stdout: "", success: true })));
+
+    // Falls back to "none": no file is gathered, and nothing is refused either.
+    await pluginCommandsCtrl.invoke("acme", "count");
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith("acme", "count", expect.objectContaining({ file: null }));
+  });
+
+  it("leaves the `commit` context's existing permissiveness alone", async () => {
+    // Deliberately NOT symmetrical with `file`: {sha} has shipped, and plugins
+    // may already rely on running without a selection. Changing that belongs in
+    // its own change, not smuggled in with a new token.
+    (bridge.state as unknown as { selectedRow: number }).selectedRow = -1;
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({ stdout: "ok", success: true })));
+
+    await pluginCommandsCtrl.invoke("acme", "onCommit", "commit");
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith("acme", "onCommit", expect.objectContaining({ sha: null }));
   });
 });

--- a/src/islands/plugincommands/plugincommands.svelte.test.ts
+++ b/src/islands/plugincommands/plugincommands.svelte.test.ts
@@ -30,12 +30,21 @@ vi.mock("../../ipc/env", () => ({ IN_TAURI: true }));
 // Mocked for the same reason bridge is: importing the real one drags in the
 // resolver/blame/filehistory/externaltools graph this controller has no
 // business booting.
-vi.mock("../detail/detail.svelte.ts", () => ({ detailCtrl: { selectedFile: null as string | null } }));
+vi.mock("../detail/detail.svelte.ts", () => ({
+  detailCtrl: { selectedFile: null as string | null, commit: {} as unknown },
+}));
+
+// The working tree keeps its OWN file selection, and `selected` is what says
+// which of the two views `#detail` is currently showing.
+vi.mock("../workdir/workdir.svelte.ts", () => ({
+  workdirCtrl: { selected: false, selectedDiffFile: null as string | null },
+}));
 
 import { commands } from "../../ipc/bindings";
 import * as bridge from "../../legacy/bridge";
 import type { CommandOutput, Plugin } from "../../ipc/bindings";
 import { detailCtrl } from "../detail/detail.svelte.ts";
+import { workdirCtrl } from "../workdir/workdir.svelte.ts";
 import { parseTamaReaction, pluginCommandsCtrl } from "./plugincommands.svelte.ts";
 
 function ok<T>(data: T): { status: "ok"; data: T } {
@@ -60,6 +69,9 @@ function resetCtrl() {
   (bridge.state as unknown as { selectedRow: number }).selectedRow = -1;
   (bridge.BACKEND as unknown as { rows: Array<{ sha: string }> }).rows = [];
   detailCtrl.selectedFile = null;
+  (detailCtrl as { commit: unknown }).commit = { sha: "abc" };
+  workdirCtrl.selected = false;
+  workdirCtrl.selectedDiffFile = null;
 }
 
 beforeEach(() => {
@@ -494,5 +506,67 @@ describe("invoke — the `file` context fills {file} (#76)", () => {
     await pluginCommandsCtrl.invoke("acme", "onCommit", "commit");
 
     expect(commands.runPluginCommand).toHaveBeenCalledWith("acme", "onCommit", expect.objectContaining({ sha: null }));
+  });
+});
+
+describe("{file} follows the view the user is actually looking at", () => {
+  // Every case here passes the context explicitly, so no manifest is needed —
+  // what is under test is which selection {file} comes from, not how the
+  // context is resolved (that has its own suite above).
+  it("takes the WORKING TREE's selection when the pinned row is what is showing", async () => {
+    // The bug: detail's field survives the switch to the working tree, so
+    // reading only it hands the command a file from a commit that has left the
+    // screen — a real path a `mutates` command would act on without complaint.
+    detailCtrl.selectedFile = "src/from-a-commit.ts";
+    workdirCtrl.selected = true;
+    workdirCtrl.selectedDiffFile = "src/in-the-worktree.ts";
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({})));
+
+    await pluginCommandsCtrl.invoke("acme", "lint", "file");
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith(
+      "acme",
+      "lint",
+      expect.objectContaining({ file: "src/in-the-worktree.ts" }),
+    );
+  });
+
+  it("refuses while the working tree is showing with no file picked, stale detail field or not", async () => {
+    detailCtrl.selectedFile = "src/from-a-commit.ts";
+    workdirCtrl.selected = true;
+    workdirCtrl.selectedDiffFile = null;
+
+    await pluginCommandsCtrl.invoke("acme", "lint", "file");
+
+    expect(commands.runPluginCommand).not.toHaveBeenCalled();
+    expect(bridge.tama.warn).toHaveBeenCalled();
+  });
+
+  it("refuses after deselecting, where detail keeps the last file but shows no commit", async () => {
+    // deselect() clears `commit` and not the file, and setCommit(null) returns
+    // before the block that would have cleared it.
+    detailCtrl.selectedFile = "src/still-here.ts";
+    (detailCtrl as { commit: unknown }).commit = null;
+    workdirCtrl.selected = false;
+
+    await pluginCommandsCtrl.invoke("acme", "lint", "file");
+
+    expect(commands.runPluginCommand).not.toHaveBeenCalled();
+    expect(bridge.tama.warn).toHaveBeenCalled();
+  });
+
+  it("still uses the commit view's file when a commit is what is showing", async () => {
+    detailCtrl.selectedFile = "src/from-a-commit.ts";
+    workdirCtrl.selected = false;
+    workdirCtrl.selectedDiffFile = "src/ignored.ts";
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({})));
+
+    await pluginCommandsCtrl.invoke("acme", "lint", "file");
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith(
+      "acme",
+      "lint",
+      expect.objectContaining({ file: "src/from-a-commit.ts" }),
+    );
   });
 });

--- a/src/islands/plugincommands/plugincommands.svelte.ts
+++ b/src/islands/plugincommands/plugincommands.svelte.ts
@@ -24,6 +24,7 @@ import * as bridge from "../../legacy/bridge";
 import { IN_TAURI } from "../../ipc/env";
 import { t, be } from "@/i18n/i18n.svelte.ts";
 import { detailCtrl } from "../detail/detail.svelte.ts";
+import { workdirCtrl } from "../workdir/workdir.svelte.ts";
 import type { Plugin, PluginContext, PlaceholderCtx } from "../../ipc/bindings";
 import type { ActionItem } from "../cmdk/cmdk.svelte.ts";
 
@@ -319,17 +320,30 @@ class PluginCommandsState {
     }
   }
 
-  // The currently-selected file, repo-relative, straight off the detail
-  // island's own selection state — the same string the diff view is showing.
-  // Null when no file is selected, which includes every moment before a commit
-  // (or the working-tree row) has been opened, since selectFile() is what sets
-  // it and switching commits clears it.
+  // The file the user is actually LOOKING AT, which is not one field.
   //
-  // Peer-island singleton import, the same route cmdk already uses to reach
-  // this controller. detail's own import graph does not lead back here, so
-  // there is no cycle to break.
+  // `#detail` shows either the pinned working-tree row or a commit, never both
+  // — Detail.svelte branches on `workdirCtrl.selected` to decide which — and
+  // each side keeps its OWN file selection: `workdirCtrl.selectedDiffFile` and
+  // `detailCtrl.selectedFile`. Reading only detail's is how a command ends up
+  // with a path from a commit that has left the screen, which is worse than
+  // the empty `{file}` the refusal in ctxFor() exists to prevent: an empty
+  // token makes the command fail loudly, a stale one is a REAL path that a
+  // `mutates` command will act on without complaint.
+  //
+  // Detail's field also outlives its own view. setCommit() returns at
+  // `if (!c) return` before the block that clears it, and deselect() clears
+  // `commit` but not the file, so after clicking empty canvas the last file is
+  // still sitting there. Gating on `commit` is what keeps that from counting
+  // as a selection.
+  //
+  // Peer-island singleton imports, the same route cmdk uses to reach this
+  // controller. Neither detail's nor workdir's import graph leads back here,
+  // so there is no cycle to break.
   private selectedFile(): string | null {
     try {
+      if (workdirCtrl.selected) return workdirCtrl.selectedDiffFile || null;
+      if (!detailCtrl.commit) return null;
       return detailCtrl.selectedFile || null;
     } catch {
       return null;

--- a/src/islands/plugincommands/plugincommands.svelte.ts
+++ b/src/islands/plugincommands/plugincommands.svelte.ts
@@ -23,6 +23,7 @@ import { commands } from "../../ipc/bindings";
 import * as bridge from "../../legacy/bridge";
 import { IN_TAURI } from "../../ipc/env";
 import { t, be } from "@/i18n/i18n.svelte.ts";
+import { detailCtrl } from "../detail/detail.svelte.ts";
 import type { Plugin, PluginContext, PlaceholderCtx } from "../../ipc/bindings";
 import type { ActionItem } from "../cmdk/cmdk.svelte.ts";
 
@@ -174,6 +175,7 @@ class PluginCommandsState {
     }
     try {
       const res = await commands.listPlugins();
+      if (res.status === "ok") this.indexContexts(res.data);
       this.actions = res.status === "ok" ? this.build(res.data) : [];
     } catch {
       // A failed registry read must never break the palette — the static
@@ -205,23 +207,65 @@ class PluginCommandsState {
     return out;
   }
 
-  // The one thing a palette entry does: call the backend command. Declarative
-  // — this never touches the manifest's `run` template (the Rust side expands
-  // it). Builds the PlaceholderCtx from what the bridge actually exposes: the
-  // open repo always, plus the selected commit's sha for a `commit` command.
-  // (The bridge exposes no selected-file state, so a `file` command falls back
-  // to repo-only — see selectedSha's counterpart absence.)
-  async invoke(pluginId: string, commandId: string, context?: PluginContext): Promise<void> {
+  // Build the placeholder context a command's `run` template gets expanded
+  // against, or null — having already told the user what was missing — when
+  // the selection the command declared it needs isn't there.
+  //
+  // `context` is the command's OWN declared context. Callers holding the
+  // manifest entry pass it; the ones that don't (a panel button knows only a
+  // command id) leave it out and it is looked up. That lookup is what lets
+  // every declarative surface fill the same tokens from the same state without
+  // each one restating the rule.
+  //
+  // A `file` command with nothing selected is REFUSED rather than run with an
+  // empty `{file}`. The asymmetry with `commit` is deliberate: an unfilled
+  // token expands to the EMPTY STRING (see plugin_exec.rs's substitute), so
+  // `rm -rf {repo}/{file}` with no selection is `rm -rf <repo>/` — the whole
+  // repository. `{file}` is new here, so nothing can depend on the old
+  // repo-only behaviour; `{sha}` keeps its existing permissiveness rather than
+  // changing under plugins that already ship.
+  ctxFor(pluginId: string, commandId: string, context?: PluginContext): PlaceholderCtx | null {
     const repo = bridge.CUR_REPO as unknown as string | null;
     if (!repo) {
       bridge.tama.warn(t("plugincommands.open_repo_first"));
-      return;
+      return null;
     }
+    const kind = context ?? this.contexts.get(`${pluginId}:${commandId}`) ?? "none";
     const ctx: PlaceholderCtx = { repo, sha: null, file: null, files: [], diff: null, branch: null, ref: null };
-    if (context === "commit") {
+    if (kind === "commit") {
       const sha = this.selectedSha();
       if (sha) ctx.sha = sha;
     }
+    if (kind === "file") {
+      const file = this.selectedFile();
+      if (!file) {
+        bridge.tama.warn(t("plugincommands.select_file_first"));
+        return null;
+      }
+      ctx.file = file;
+    }
+    return ctx;
+  }
+
+  // `pluginId:commandId` -> the context that command declared. Indexed over
+  // EVERY command of every enabled plugin, not just the palette-placed subset
+  // build() keeps, because a panel button can name a `menu`-only command.
+  private contexts = new Map<string, PluginContext>();
+
+  private indexContexts(plugins: Plugin[]): void {
+    this.contexts.clear();
+    for (const p of plugins) {
+      if (p.enabled === false) continue;
+      for (const c of p.commands ?? []) this.contexts.set(`${p.id}:${c.id}`, c.context ?? "none");
+    }
+  }
+
+  // The one thing a palette entry does: call the backend command. Declarative
+  // — this never touches the manifest's `run` template (the Rust side expands
+  // it).
+  async invoke(pluginId: string, commandId: string, context?: PluginContext): Promise<void> {
+    const ctx = this.ctxFor(pluginId, commandId, context);
+    if (!ctx) return; // ctxFor has already warned about what was missing
     if (!IN_TAURI) {
       bridge.tama.say(t("plugincommands.demo_run"));
       return;
@@ -270,6 +314,23 @@ class PluginCommandsState {
       const backend = bridge.BACKEND as unknown as { rows: Array<{ sha?: string }> } | null;
       const m = backend && backend.rows ? backend.rows[row] : null;
       return (m && m.sha) || null;
+    } catch {
+      return null;
+    }
+  }
+
+  // The currently-selected file, repo-relative, straight off the detail
+  // island's own selection state — the same string the diff view is showing.
+  // Null when no file is selected, which includes every moment before a commit
+  // (or the working-tree row) has been opened, since selectFile() is what sets
+  // it and switching commits clears it.
+  //
+  // Peer-island singleton import, the same route cmdk already uses to reach
+  // this controller. detail's own import graph does not lead back here, so
+  // there is no cycle to break.
+  private selectedFile(): string | null {
+    try {
+      return detailCtrl.selectedFile || null;
     } catch {
       return null;
     }

--- a/src/islands/pluginpanels/pluginpanels.svelte.test.ts
+++ b/src/islands/pluginpanels/pluginpanels.svelte.test.ts
@@ -34,7 +34,15 @@ vi.mock("../../ipc/env", () => ({ IN_TAURI: true }));
 // The detail island owns the file selection a `file` command's {file} is
 // filled from (#76). Mocked so this test does not boot detail's own import
 // graph (resolver/blame/filehistory/externaltools) just to read one string.
-vi.mock("../detail/detail.svelte.ts", () => ({ detailCtrl: { selectedFile: null as string | null } }));
+vi.mock("../detail/detail.svelte.ts", () => ({
+  detailCtrl: { selectedFile: null as string | null, commit: {} as unknown },
+}));
+
+// ...and the working tree, which keeps its own file selection. `selected` says
+// which of the two `#detail` is showing; false here means the commit view.
+vi.mock("../workdir/workdir.svelte.ts", () => ({
+  workdirCtrl: { selected: false, selectedDiffFile: null as string | null },
+}));
 
 import { commands } from "../../ipc/bindings";
 import * as bridge from "../../legacy/bridge";

--- a/src/islands/pluginpanels/pluginpanels.svelte.test.ts
+++ b/src/islands/pluginpanels/pluginpanels.svelte.test.ts
@@ -11,9 +11,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../legacy/bridge", () => ({
   CUR_REPO: "/repo",
   tama: { set: vi.fn(), say: vi.fn(), warn: vi.fn(), event: vi.fn() },
-  // pluginCommandsCtrl.invoke (which runButton delegates to) reads these for a
-  // `commit` context; runButton passes no context, so they stay untouched, but
-  // they're present so the module never dereferences an undefined bridge field.
+  // pluginCommandsCtrl.ctxFor (which both runButton and runCommandOutput go
+  // through) reads these for a `commit` command. Since #76 the context is
+  // resolved from the MANIFEST when the caller passes none, so a panel widget
+  // naming a `commit` command does now reach these.
   state: { selectedRow: -1 },
   BACKEND: { rows: [] as Array<{ sha: string }> },
   TAMA_IMG: { curious: "curious.png" },
@@ -30,9 +31,16 @@ vi.mock("../../ipc/bindings", () => ({
 // mock it so the real (non-demo) branches run.
 vi.mock("../../ipc/env", () => ({ IN_TAURI: true }));
 
+// The detail island owns the file selection a `file` command's {file} is
+// filled from (#76). Mocked so this test does not boot detail's own import
+// graph (resolver/blame/filehistory/externaltools) just to read one string.
+vi.mock("../detail/detail.svelte.ts", () => ({ detailCtrl: { selectedFile: null as string | null } }));
+
 import { commands } from "../../ipc/bindings";
 import * as bridge from "../../legacy/bridge";
 import type { CommandOutput, Plugin, PluginPanel } from "../../ipc/bindings";
+import { detailCtrl } from "../detail/detail.svelte.ts";
+import { pluginCommandsCtrl } from "../plugincommands/plugincommands.svelte.ts";
 import { pluginPanelsCtrl } from "./pluginpanels.svelte.ts";
 
 function ok<T>(data: T): { status: "ok"; data: T } {
@@ -305,5 +313,68 @@ describe("design mode (!IN_TAURI) is graceful", () => {
     await ctrl.runButton("acme", "doit");
     expect(bindingsDemo.commands.runPluginCommand).not.toHaveBeenCalled();
     expect(ctrl.runningButtons.doit).toBeUndefined();
+  });
+});
+
+describe("a widget inherits the context its command declared (#76)", () => {
+  const filePanel: PluginPanel = {
+    id: "review",
+    title: "Review",
+    items: [{ type: "command-output", command: "lint", label: "Lint" }],
+  };
+  const acme = plugin({
+    id: "acme",
+    name: "Acme",
+    panels: [filePanel],
+    commands: [
+      { id: "lint", label: "Lint", run: "lint {file}", handler: null, context: "file", placement: "palette", mutates: false },
+    ],
+  });
+
+  beforeEach(() => {
+    detailCtrl.selectedFile = null;
+    // pluginCommandsCtrl caches its manifest read; force a fresh one so this
+    // suite's own plugin lands in its context index.
+    pluginCommandsCtrl.loaded = false;
+    pluginCommandsCtrl.actions = [];
+  });
+
+  // openPanel() fires the command-output run itself; these tests want to drive
+  // runCommandOutput directly, so open the panel and let that first, unmocked
+  // run settle before asserting on a second, deliberate one.
+  async function openReview(): Promise<void> {
+    vi.mocked(commands.listPlugins).mockResolvedValue(ok([acme]));
+    await pluginCommandsCtrl.ensureLoaded();
+    await pluginPanelsCtrl.ensureLoaded();
+    vi.mocked(commands.runPluginCommand).mockResolvedValue(ok(output({ stdout: "", success: true })));
+    pluginPanelsCtrl.openPanel("acme", "review");
+    await flush();
+    vi.clearAllMocks();
+  }
+
+  it("a command-output widget naming a `file` command gets {file} filled", async () => {
+    await openReview();
+    detailCtrl.selectedFile = "src/app.ts";
+    vi.mocked(commands.runPluginCommand).mockResolvedValueOnce(ok(output({ stdout: "clean", success: true })));
+
+    await pluginPanelsCtrl.runCommandOutput(0);
+
+    expect(commands.runPluginCommand).toHaveBeenCalledWith(
+      "acme",
+      "lint",
+      expect.objectContaining({ repo: "/repo", file: "src/app.ts" }),
+    );
+  });
+
+  it("the same widget shows an error instead of running with an empty {file}", async () => {
+    await openReview();
+    detailCtrl.selectedFile = null;
+
+    await pluginPanelsCtrl.runCommandOutput(0);
+
+    expect(commands.runPluginCommand).not.toHaveBeenCalled();
+    expect(bridge.tama.warn).toHaveBeenCalled();
+    // and the spinner must not be left running for output that never comes
+    expect(pluginPanelsCtrl.outputs[0]).toEqual(expect.objectContaining({ running: false }));
   });
 });

--- a/src/islands/pluginpanels/pluginpanels.svelte.ts
+++ b/src/islands/pluginpanels/pluginpanels.svelte.ts
@@ -33,7 +33,7 @@ import * as bridge from "../../legacy/bridge";
 import { IN_TAURI } from "../../ipc/env";
 import { t, be } from "@/i18n/i18n.svelte.ts";
 import { parseTamaReaction, pluginCommandsCtrl } from "../plugincommands/plugincommands.svelte.ts";
-import type { Plugin, PluginPanel, PlaceholderCtx } from "../../ipc/bindings";
+import type { Plugin, PluginPanel } from "../../ipc/bindings";
 import type { ActionItem } from "../cmdk/cmdk.svelte.ts";
 
 // The live render state of a single `command-output` widget: its captured
@@ -192,16 +192,6 @@ class PluginPanelsState {
     this.open = false;
   }
 
-  // Repo-only placeholder context — the declarative path expands the command's
-  // OWN template against this on the backend. Panels carry no per-widget
-  // commit/file selection, so (unlike plugincommands.invoke's `commit`-context
-  // sha gathering) this is deliberately just the open repo. Read CUR_REPO at
-  // call time (live binding — never destructured).
-  private ctx(): PlaceholderCtx {
-    const repo = bridge.CUR_REPO as unknown as string | null;
-    return { repo: repo ?? null, sha: null, file: null, files: [], diff: null, branch: null, ref: null };
-  }
-
   private setOutput(index: number, value: PanelOutput): void {
     this.outputs = { ...this.outputs, [index]: value };
   }
@@ -227,8 +217,21 @@ class PluginPanelsState {
       return;
     }
 
+    // Same placeholder context the palette builds, from the same state, keyed
+    // off the CONTEXT THE COMMAND DECLARED — so a widget naming a `file`
+    // command gets `{file}` filled exactly like the ⌘K entry for it would,
+    // and is refused the same way when nothing is selected. A panel widget
+    // carries no selection of its own; the command it names is what decides
+    // what it needs.
+    const ctx = pluginCommandsCtrl.ctxFor(pluginId, item.command);
+    if (!ctx) {
+      // ctxFor has already warned through Tama; the panel just stops showing a
+      // spinner for output that is never coming.
+      this.setOutput(index, { running: false, text: "", error: t("pluginpanels.err_command_failed") });
+      return;
+    }
     try {
-      const res = await commands.runPluginCommand(pluginId, item.command, this.ctx());
+      const res = await commands.runPluginCommand(pluginId, item.command, ctx);
       if (res.status !== "ok") {
         this.setOutput(index, { running: false, text: "", error: be(res.error) || t("pluginpanels.err_command_failed") });
         return;


### PR DESCRIPTION
Part 3 of 3. **Stacked on #116**, which is stacked on #115. Do not merge before both.

`#65 → #63 → #76`

## What

All three invocation sites built the same repo-only `PlaceholderCtx`, so a plugin command received almost nothing. The in-code excuse — "the bridge exposes no selected-file state" — stopped being true once `detail.svelte.ts` grew `selectedFile`, which is the same string the diff view is showing, repo-relative, reachable by the peer-island import route ⌘K already uses.

## The rule, stated once

`ctxFor()` now owns it, and every declarative surface goes through it: **the command's own declared context decides which tokens get filled.** Callers holding the manifest entry pass the context; callers holding only a plugin id and a command id (a panel button, a command-output widget) leave it out and it is looked up in an index built at load time.

That is what makes panels fill the same tokens as the palette without either surface restating the rule. It has one side effect worth naming: a panel widget naming a `commit` command now gets `{sha}`, which it did not before. That looks like the behaviour a panel author would expect, but say so if you disagree.

## The one judgement call

**A `file` command with nothing selected is refused rather than run.** An unfilled token expands to the empty string, so `rm -rf {repo}/{file}` with no selection is `rm -rf <repo>/` — the repository.

Deliberately *not* symmetrical with `commit`: `{sha}` has shipped and plugins may already rely on running without a selection, so changing that belongs in its own change rather than riding along with a new token. `{file}` is new here, so nothing can depend on its old repo-only behaviour. Happy to make them symmetrical in a follow-up if you'd rather.

## Scope

`{file}` only, as the issue asks. `{branch}`, `{ref}` and `{diff}` are all obtainable from git inside a command that already runs with the repo as its cwd, and `{files}` needs its meaning decided first (#77). Hooks stay repo-only — they fire on events, not selections.

The docs now say plainly which tokens are filled today (`{repo}`, `{sha}`, `{file}`) instead of implying all seven work.

## Checks

`pnpm check` clean. 58 tests pass across the two controllers and i18n, 7 new — including a panel widget inheriting its command's file context, and the refusal path leaving no spinner behind.

Closes #76.
