### PR TITLE
Fix three follow-ups before 1.3.0 ships

### DIFF
--- a/e2e/detail-placement.spec.ts
+++ b/e2e/detail-placement.spec.ts
@@ -348,6 +348,12 @@ test("the resize guide keeps its axis through the fade and leaks no inset across
   const guide = page.locator(".resize-guide");
   const bottom = page.locator("#resizeDetailBottom");
   const hb = (await bottom.boundingBox())!;
+  // hover() first, for the reason the drag test above records: the dismissed
+  // wizard scrim keeps intercepting pointer events through its fade-out, and
+  // the raw page.mouse calls below do no actionability wait of their own. Skip
+  // it and pointerdown never reaches the handle, so the guide — created lazily
+  // by beginDrag — is never created at all.
+  await bottom.hover();
   await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2);
   await page.mouse.down();
   await page.mouse.move(hb.x + hb.width / 2, hb.y - 120);
@@ -370,6 +376,7 @@ test("the resize guide keeps its axis through the fade and leaks no inset across
   // both placements, so the second drag needs no placement change at all.
   const side = page.locator("#resizeSidebar");
   const sb = (await side.boundingBox())!;
+  await side.hover();
   await page.mouse.move(sb.x + sb.width / 2, sb.y + sb.height / 2);
   await page.mouse.down();
   await page.mouse.move(sb.x + sb.width / 2 + 60, sb.y + sb.height / 2);

--- a/e2e/detail-placement.spec.ts
+++ b/e2e/detail-placement.spec.ts
@@ -337,3 +337,67 @@ test("the changes divider drags, and resizes the file pane, in both placements",
   const afterX = (await files.boundingBox())!;
   expect(afterX.width).toBeGreaterThan(beforeX.width + 60);
 });
+
+// One guide element serves both handles, so anything it keeps from the last
+// drag shows up on the next one — on the opposite axis.
+test("the resize guide keeps its axis through the fade and leaks no inset across axes", async ({ page }) => {
+  await page.goto("/");
+  await skipWizard(page);
+  await usePlacement(page, "bottom");
+
+  const guide = page.locator(".resize-guide");
+  const bottom = page.locator("#resizeDetailBottom");
+  const hb = (await bottom.boundingBox())!;
+  await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(hb.x + hb.width / 2, hb.y - 120);
+  await expect(guide).toHaveClass(/horiz/);
+  await page.mouse.up();
+
+  // Read once, WITHOUT a retrying matcher: the bug is that onUp dropped `horiz`
+  // while the line was still fading, so the line snapped from horizontal to
+  // vertical mid-fade. A retrying expect would happily wait out the fade and
+  // miss it.
+  expect(await guide.evaluate((el) => el.classList.contains("horiz"))).toBe(true);
+
+  // That vertical drag set an inline `top`. A horizontal drag sets `left` and
+  // never touches `top`, so without clearing it the sidebar's guide would start
+  // at the bottom panel's last Y instead of spanning the window.
+  //
+  // Deliberately NO reload between the two drags: a reload throws the guide
+  // element away, and a fresh one trivially has no inline `top` — which would
+  // make the assertion below unable to fail. The sidebar handle is present in
+  // both placements, so the second drag needs no placement change at all.
+  const side = page.locator("#resizeSidebar");
+  const sb = (await side.boundingBox())!;
+  await page.mouse.move(sb.x + sb.width / 2, sb.y + sb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(sb.x + sb.width / 2 + 60, sb.y + sb.height / 2);
+  expect(await guide.evaluate((el) => (el as HTMLElement).style.top)).toBe("");
+  await page.mouse.up();
+});
+
+// The tooltip describes the handle's own state, so a collapse has to move it on
+// BOTH of #detail's handles, not just the one that started it.
+test("both detail handles carry a tooltip, and it follows a collapse from either edge", async ({ page }) => {
+  await page.goto("/");
+  await skipWizard(page);
+  await usePlacement(page, "bottom");
+
+  const bottom = page.locator("#resizeDetailBottom");
+  const right = page.locator("#resizeDetail");
+  await expect(bottom).toHaveAttribute("title", /Drag to resize/);
+
+  // Collapse through the bottom handle (focus mode resolves to it in this
+  // placement), then read the RIGHT handle — the peer that did not initiate it.
+  await page.keyboard.press("Control+Backslash");
+  await expect(page.locator("#detail")).toHaveClass(/collapsed/);
+  await expect(bottom).toHaveAttribute("title", /Click to expand/);
+  await expect(right).toHaveAttribute("title", /Click to expand/);
+
+  await page.keyboard.press("Control+Backslash");
+  await expect(page.locator("#detail")).not.toHaveClass(/collapsed/);
+  await expect(right).toHaveAttribute("title", /Drag to resize/);
+  await expect(bottom).toHaveAttribute("title", /Drag to resize/);
+});
+

--- a/index.html
+++ b/index.html
@@ -2240,7 +2240,7 @@ button{font-family:inherit;font-size:inherit;color:inherit;cursor:pointer}
   </main>
 
   <!-- ============================ DETAIL PANEL ============================ -->
-  <section class="detail" id="detail"><div class="resize-handle detail-handle" id="resizeDetail" role="button" tabindex="0" aria-label="Resize detail panel" title="Drag to resize — drag past the edge to collapse"></div><div class="resize-handle detail-handle-bottom" id="resizeDetailBottom" role="button" tabindex="0" aria-label="Resize detail panel"></div><!-- filled by the Detail Svelte island (src/islands/detail) --></section>
+  <section class="detail" id="detail"><div class="resize-handle detail-handle" id="resizeDetail" role="button" tabindex="0" aria-label="Resize detail panel" title="Drag to resize — drag past the edge to collapse"></div><div class="resize-handle detail-handle-bottom" id="resizeDetailBottom" role="button" tabindex="0" aria-label="Resize detail panel" title="Drag to resize — drag past the edge to collapse"></div><!-- filled by the Detail Svelte island (src/islands/detail) --></section>
 
 </div>
 

--- a/src-tauri/src/repo_registry.rs
+++ b/src-tauri/src/repo_registry.rs
@@ -183,13 +183,50 @@ fn migrate_verbatim_paths(repos: Vec<TrackedRepo>) -> Vec<TrackedRepo> {
     let mut out: Vec<TrackedRepo> = Vec::with_capacity(repos.len());
     for mut repo in repos {
         repo.path = crate::windows::strip_windows_verbatim_prefix(repo.path);
-        match out.iter_mut().find(|r| r.path == repo.path) {
-            Some(kept) if repo.last_opened_at > kept.last_opened_at => *kept = repo,
-            Some(_) => {}
+        match out.iter().position(|r| r.path == repo.path) {
+            // `remove` + `insert` at the same index rather than push: collapsing
+            // a pair must not move the repo in the file's existing order.
+            Some(i) => {
+                let kept = out.remove(i);
+                out.insert(i, coalesce_duplicate(kept, repo));
+            }
             None => out.push(repo),
         }
     }
     out
+}
+
+/// Collapse two rows that turned out to name the same repo.
+///
+/// This used to keep the more recently opened row WHOLE, which quietly threw
+/// away everything the other row remembered. That is worse than it sounds: the
+/// newer row is often the one that was added and barely used, while the older
+/// spelling carries the branch filter the user actually curated. And since the
+/// collapse happens once, automatically, on the upgrade that strips the
+/// verbatim prefix — and the next `save_to` persists the result — whatever it
+/// drops is dropped for good.
+///
+/// So recency decides ORDERING, and every other field comes from whichever row
+/// actually has something to say.
+fn coalesce_duplicate(a: TrackedRepo, b: TrackedRepo) -> TrackedRepo {
+    let (newer, older) = if b.last_opened_at > a.last_opened_at { (b, a) } else { (a, b) };
+    // Auto mode OWNS visible_local_branches — it recomputes and overwrites the
+    // list — so the flag has to travel with whichever row supplies that list.
+    // Reading the flag off the newer row while taking the older row's list
+    // would leave the two describing different states.
+    let local_from_newer = newer.visible_local_branches.is_some();
+    TrackedRepo {
+        path: newer.path,
+        last_opened_at: newer.last_opened_at.or(older.last_opened_at),
+        // Either row having shown it means the user has already seen it; `false`
+        // would re-arm a one-time auto-show they dismissed.
+        repo_summary_shown: newer.repo_summary_shown || older.repo_summary_shown,
+        auto_branch_visibility: if local_from_newer { newer.auto_branch_visibility } else { older.auto_branch_visibility },
+        // `None` means "no filter at all", not "an empty filter", so a newer row
+        // that never had one must not erase the older row's.
+        visible_local_branches: newer.visible_local_branches.or(older.visible_local_branches),
+        visible_remote_branches: newer.visible_remote_branches.or(older.visible_remote_branches),
+    }
 }
 
 /// Process-wide lock serializing every registry read-modify-write sequence
@@ -664,6 +701,58 @@ mod tests {
         ]);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].last_opened_at, Some(1));
+    }
+
+    // Collapsing a pair must not throw away what the losing row remembered.
+    // This runs once, automatically, on upgrade, and `save_to` then persists
+    // the result — so anything dropped here is dropped permanently.
+    #[test]
+    fn migration_coalesces_the_pair_rather_than_overwriting_the_older_row() {
+        // The shape that actually bites: the newer row is one that was added and
+        // barely used, while the older spelling carries the curated filter.
+        let mut old_row = row(r"\\?\C:\Users\me\proj", Some(10));
+        old_row.visible_local_branches = Some(vec!["main".into(), "dev".into()]);
+        old_row.visible_remote_branches = Some(vec!["origin/main".into()]);
+        old_row.auto_branch_visibility = true;
+        old_row.repo_summary_shown = true;
+
+        let out = migrate_verbatim_paths(vec![old_row, row(r"C:\Users\me\proj", Some(99))]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].last_opened_at, Some(99), "recency still decides ordering");
+        assert_eq!(
+            out[0].visible_local_branches.as_deref(),
+            Some(["main".to_string(), "dev".to_string()].as_slice()),
+            "a newer row with no filter must not erase the older row's"
+        );
+        assert_eq!(out[0].visible_remote_branches.as_deref(), Some(["origin/main".to_string()].as_slice()));
+        assert!(out[0].auto_branch_visibility, "the flag travels with the list it owns");
+        assert!(out[0].repo_summary_shown, "already-seen must not be re-armed");
+    }
+
+    #[test]
+    fn coalescing_prefers_the_newer_rows_filter_when_both_have_one() {
+        let mut older = row(r"\\?\C:\p", Some(10));
+        older.visible_local_branches = Some(vec!["stale".into()]);
+        older.auto_branch_visibility = true;
+        let mut newer = row(r"C:\p", Some(99));
+        newer.visible_local_branches = Some(vec!["current".into()]);
+        newer.auto_branch_visibility = false;
+
+        let out = migrate_verbatim_paths(vec![older, newer]);
+        assert_eq!(out[0].visible_local_branches.as_deref(), Some(["current".to_string()].as_slice()));
+        assert!(!out[0].auto_branch_visibility, "the flag comes from whichever row supplied the list");
+    }
+
+    #[test]
+    fn coalescing_keeps_the_repos_place_in_the_files_order() {
+        let out = migrate_verbatim_paths(vec![
+            row("/a", Some(1)),
+            row(r"\\?\C:\dup", Some(2)),
+            row("/b", Some(3)),
+            row(r"C:\dup", Some(99)),
+        ]);
+        let paths: Vec<&str> = out.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(paths, vec!["/a", r"C:\dup", "/b"], "the collapsed row keeps the first spelling's slot");
     }
 
     // The migration has to run where the data actually arrives — reading the

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -1983,6 +1983,11 @@ function resizeGuide(vert){
   // One element, re-oriented per drag: only one drag can be in flight at a
   // time, so a second element would just be state to keep in sync.
   resizeGuideEl.classList.toggle("horiz",!!vert);
+  // ...which is exactly why the OTHER axis's inline inset has to go with it. A
+  // vertical drag sets `top` and a horizontal one sets `left`, so a leftover
+  // `top` from a bottom-panel drag would make the next sidebar guide start at
+  // that Y instead of spanning the window.
+  if(vert) resizeGuideEl.style.left=""; else resizeGuideEl.style.top="";
   return resizeGuideEl;
 }
 
@@ -2027,7 +2032,12 @@ function wireResizeHandle(handle,cssVar,min,max,fromFarEdge,railW,axis="x"){
   panelHandlePeers.set(panel,peers);
   // What a peer does when SOMEONE ELSE'S handle collapses or expands this
   // panel: move its own custom property to match, to its own remembered size.
-  const me={ applyCollapsed(v){ root.style.setProperty(cssVar,(v?railW:lastExpandedSize)+"px"); } };
+  // The tooltip describes THIS handle's own state, so it moves with the
+  // collapse rather than only on the handle that initiated it — collapsing via
+  // the bottom edge (or ⌘\) used to leave the right handle still offering to
+  // "drag to resize" something already collapsed.
+  const handleTitle=v=>v?"Click to expand":"Drag to resize — drag past the edge to collapse";
+  const me={ applyCollapsed(v){ root.style.setProperty(cssVar,(v?railW:lastExpandedSize)+"px"); handle.title=handleTitle(v); } };
   peers.push(me);
   // `collapsed` is read from the parent's own `.collapsed` class rather than
   // kept as a private variable on this closure: the right-edge and bottom
@@ -2042,7 +2052,7 @@ function wireResizeHandle(handle,cssVar,min,max,fromFarEdge,railW,axis="x"){
   function setCollapsed(v){
     const was=isCollapsed();
     panel.classList.toggle("collapsed",v);
-    handle.title=v?"Click to expand":"Drag to resize — drag past the edge to collapse";
+    handle.title=handleTitle(v);
     // The `collapsed` class is shared (see isCollapsed), but each handle owns a
     // DIFFERENT custom property — so flipping only this one's leaves the other
     // axis wherever it was. Collapse #detail in "bottom" (⌘\), switch to
@@ -2077,7 +2087,10 @@ function wireResizeHandle(handle,cssVar,min,max,fromFarEdge,railW,axis="x"){
     document.removeEventListener("pointermove",onMove);
     document.removeEventListener("pointerup",onUp);
     handle.classList.remove("active"); root.classList.remove("resizing","resizing-y");
-    resizeGuide().classList.remove("on","will-collapse"); // hide the guide line
+    // Pass `vert` here too: calling this bare drops the `horiz` class while the
+    // line is still fading out, so it snaps from a horizontal bar to a vertical
+    // one mid-fade.
+    resizeGuide(vert).classList.remove("on","will-collapse"); // hide the guide line
     if(!dragged){
       // A plain click, no drag at all: only meaningful while collapsed
       // (reopen); a click on an already-expanded handle is a no-op, same as


### PR DESCRIPTION
Three fixes that were all raised as non-blocking follow-ups when #98/#106/#109/#113 were approved. Cursor Bugbot, run at high effort against the release PR (#119), independently found the same set — plus two more that are internal only and are now #120 and #121.

The first one is why these are not staying follow-ups: **it destroys user state, and it fires on the upgrade to 1.3.0.**

## 1. The registry migration overwrote a row instead of coalescing it

`migrate_verbatim_paths` kept the more recently opened row *whole*, dropping the other row's `visible_local_branches`, `visible_remote_branches`, `auto_branch_visibility` and `repo_summary_shown`.

That is worse than it sounds. The newer row is often the one that was added and barely used, while the older spelling carries the branch filter the user actually curated — and the function's own doc comment already acknowledged one repo legitimately holding both spellings. The collapse runs once, automatically, on the upgrade that strips the verbatim prefix, and `save_to` then persists the result, so whatever it dropped was dropped for good.

Recency now decides **ordering only**:

- `None` means "no filter", not "an empty filter", so a newer row without one cannot erase the older row's.
- `repo_summary_shown` ORs — either row having shown it means the user has seen it, and `false` would re-arm a one-time auto-show they dismissed.
- `auto_branch_visibility` travels with whichever row supplied `visible_local_branches`, because auto mode *recomputes and overwrites* that list. Reading the flag off the other row would leave the two describing different states.

## 2. The resize guide dropped its axis and leaked an inset

`onUp` called `resizeGuide()` bare, so `horiz` came off while the line was still fading — it snapped from a horizontal bar to a vertical one mid-fade.

The second half is the one that outlives the drag: one element serves both handles, and each axis sets its own inline inset. A leftover `top` from a bottom-panel drag survived into the next sidebar drag, where `.resize-guide`'s base rule is `top:0;bottom:0` — so the inline value won and the line started at that Y instead of spanning the window.

## 3. The bottom detail handle had no tooltip, and collapse didn't propagate it

`#resizeDetailBottom` had an `aria-label` but no `title`, unlike `#resizeDetail`. And `setCollapsed` wrote `handle.title` only on the handle that initiated the change, so collapsing through the bottom edge (or ⌘\) left the right handle still offering to "drag to resize" something already collapsed. `applyCollapsed` now carries the title too — that is the path peers already go through.

Kept as hardcoded English to match the two existing handles; all three should go through `t()` together, separately.

## Tests, and what they actually guard

Three new Rust tests, 12 pass in `repo_registry`. **Reverting the coalesce to a wholesale assignment turns the main one red** — I checked. The other two pin the precedence rule and the order preservation of the new `remove`/`insert`, and would pass either way: they document, they do not guard. Saying so because "3 tests cover it" would be the wrong impression.

Two new Playwright specs. The guide one reads the class **without a retrying matcher**, because the bug is transient and `expect().toHaveClass` would happily wait out the fade and miss it. Its cross-axis half deliberately does *not* reload between the two drags — a reload throws the guide element away and a fresh one trivially has no inline `top`, which would make that assertion unable to fail.

⚠️ **The Playwright specs were not run locally.** The browser download fails here with `ECONNRESET` against `cdn.playwright.dev`, so CI is their first execution. `pnpm check` is clean and the Rust suite passes locally.

## After this

`release/1.3.0` gets re-cut from the updated `dev`, which refreshes #119 in place rather than opening a second release PR.
