### PR TITLE
perf: mount the four plain modal islands on first open

### DIFF
--- a/e2e/lazy-islands.spec.ts
+++ b/e2e/lazy-islands.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+// #81: the four plain modal islands are mounted on FIRST OPEN, not at boot.
+//
+// The distinction these tests turn on is "absent from the DOM" versus "present
+// and hidden". Every one of these modals was previously mounted into
+// document.body at boot and rendered a hidden scrim; a `toBeHidden()` assertion
+// passes either way, so it cannot tell the two apart. `toHaveCount(0)` can.
+
+const MODALS = [
+  { name: "Settings", selector: ".modal.settings" },
+  { name: "Plugins", selector: ".modal.plugins-modal" },
+  { name: "External Tools", selector: ".modal.external-tools" },
+  { name: "Tama Gallery", selector: ".modal.tama-gallery" },
+];
+
+test("none of the lazily mounted modals is in the DOM at boot", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  await page.goto("/");
+  await page.waitForTimeout(300);
+
+  for (const m of MODALS) {
+    await expect(page.locator(m.selector), `${m.name} must not be mounted before it is opened`).toHaveCount(0);
+  }
+
+  // The controllers, unlike the views, stay eager — boot code reads them. If a
+  // controller had been lazified too, the menu/⌘K wiring that calls into it at
+  // boot would have thrown by now.
+  expect(errors).toEqual([]);
+});
+
+test("opening one mounts exactly that one, and only once", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(m.text());
+  });
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  await page.goto("/");
+  await page.waitForTimeout(300);
+
+  const settings = page.locator(".modal.settings");
+  await expect(settings).toHaveCount(0);
+
+  await page.keyboard.press("Control+,");
+  await expect(settings, "Ctrl+, should load and mount Settings").toBeVisible();
+
+  // Its siblings must still be absent — opening one modal must not drag the
+  // other three in with it, which is what a single shared chunk would do.
+  for (const m of MODALS.filter((m) => m.name !== "Settings")) {
+    await expect(page.locator(m.selector), `${m.name} must still be absent`).toHaveCount(0);
+  }
+
+  // Close and reopen: the view stays mounted and is merely hidden now, so this
+  // must not produce a SECOND copy in document.body. The guard in
+  // mountOnFirstOpen is set before its dynamic import is awaited precisely so
+  // a fast close/open cannot race two mounts.
+  await page.keyboard.press("Escape");
+  await expect(settings).toBeHidden();
+  await expect(settings).toHaveCount(1);
+  await page.keyboard.press("Control+,");
+  await expect(settings).toBeVisible();
+  await expect(settings, "reopening must not mount a second copy").toHaveCount(1);
+
+  // A failed chunk load would surface here rather than as a silent unhandled
+  // rejection — mountOnFirstOpen catches and logs.
+  expect(errors).toEqual([]);
+});

--- a/src/lazyisland.svelte.ts
+++ b/src/lazyisland.svelte.ts
@@ -1,0 +1,64 @@
+// Mount a modal island's VIEW the first time its controller opens it.
+//
+// `src/main.ts` mounts every island into `document.body` at boot. For the
+// on-demand modals that is work done for nothing: the component renders
+// nothing at all until its controller's `open` flips, yet it is downloaded,
+// parsed and mounted before the user has touched anything.
+//
+// The CONTROLLER still has to be eager — boot code reads it (menu wiring, ⌘K
+// registration, settings applied to the document) — so only the view moves.
+// That split is the whole trick: `open` is plain `$state` on a singleton that
+// already exists, so watching it costs nothing and needs no new plumbing.
+//
+// SAFE ONLY for islands whose view is pure presentation: no `onMount`, no
+// `$effect`, no listeners, and no props. An island that does work when it
+// mounts must keep its eager `mount()`, because deferring the mount defers the
+// work — silently, and until the user happens to open it. TamaGallery,
+// Plugins, Settings and ExternalTools were each checked against that bar
+// before being moved (see #81).
+//
+// Lives in a `.svelte.ts` file because `$effect` is a rune and `main.ts` is
+// plain TypeScript — the effect has to be compiled here and called from there.
+
+import { mount, type Component } from "svelte";
+
+/**
+ * Watch `isOpen()` and, the first time it is true, load and mount the view.
+ *
+ * Idempotent by construction: the guard is set BEFORE the dynamic import is
+ * awaited, so a controller that flips `open` twice in quick succession cannot
+ * race two mounts of the same component into `document.body`.
+ *
+ * The one visible consequence: the FIRST open waits for the chunk. Off the
+ * local asset protocol that is well under a frame, and every later open is
+ * exactly as it was — but it does mean the first open of a modal does not
+ * animate its scrim in, since there is no scrim in the DOM yet to animate.
+ */
+export function mountOnFirstOpen(
+  isOpen: () => boolean,
+  load: () => Promise<{ default: Component<Record<string, never>> }>,
+): void {
+  let started = false;
+  const stop = $effect.root(() => {
+    $effect(() => {
+      if (started || !isOpen()) return;
+      started = true;
+      void load()
+        .then((mod) => {
+          mount(mod.default, { target: document.body });
+          // One job, done. Nothing here needs to observe `open` again — the
+          // mounted component owns its own show/hide from now on.
+          stop();
+        })
+        .catch((err) => {
+          // A chunk that fails to load must not leave the modal permanently
+          // dead, and must not become an unhandled rejection that nothing
+          // surfaces. Clearing the guard means the next open tries again,
+          // which is the right answer for the realistic cause: a transient
+          // read of an asset that is sitting on local disk.
+          started = false;
+          console.error("lazyisland: could not load a modal view", err);
+        });
+    });
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,18 +29,16 @@ import { exportPatchesCtrl } from "./islands/exportpatches/exportpatches.svelte.
 import { applyPatchCtrl } from "./islands/applypatch/applypatch.svelte.ts";
 import Terminal from "./islands/terminal/Terminal.svelte";
 import { terminalCtrl } from "./islands/terminal/terminal.svelte.ts";
-import TamaGallery from "./islands/tamagallery/TamaGallery.svelte";
 import PickaxeSearch from "./islands/pickaxesearch/PickaxeSearch.svelte";
 import { pickaxeSearchCtrl } from "./islands/pickaxesearch/pickaxesearch.svelte.ts";
 import CodeSearch from "./islands/codesearch/CodeSearch.svelte";
 import { codeSearchCtrl } from "./islands/codesearch/codesearch.svelte.ts";
 import Dashboard from "./islands/dashboard/Dashboard.svelte";
 import { dashboardCtrl } from "./islands/dashboard/dashboard.svelte.ts";
-import ExternalTools from "./islands/externaltools/ExternalTools.svelte";
 import { externalToolsCtrl } from "./islands/externaltools/externaltools.svelte.ts";
-import Plugins from "./islands/plugins/Plugins.svelte";
+import { tamaGalleryCtrl } from "./islands/tamagallery/tamagallery.svelte.ts";
+import { mountOnFirstOpen } from "./lazyisland.svelte.ts";
 import { pluginsCtrl } from "./islands/plugins/plugins.svelte.ts";
-import Settings from "./islands/settings/Settings.svelte";
 import { settingsCtrl, loadSettings } from "./islands/settings/settings.svelte.ts";
 import DanglingRecovery from "./islands/danglingrecovery/DanglingRecovery.svelte";
 import { danglingRecoveryCtrl } from "./islands/danglingrecovery/danglingrecovery.svelte.ts";
@@ -228,19 +226,27 @@ mount(Dashboard, { target: document.body });
 // any file/commit target itself (unlike its own "Open in external diff"/
 // "Resolve with external tool" buttons, which live on Detail.svelte/
 // Workdir.svelte's file rows and Resolver.svelte instead).
-mount(ExternalTools, { target: document.body });
+// Lazily mounted (#81): the view is downloaded and mounted the first time its
+// controller opens it, not at boot. The CONTROLLER stays eager above — the
+// menu/⌘K wiring below calls straight into it — so only the markup is deferred.
+// See lazyisland.svelte.ts for what makes an island eligible; the ones that do
+// work when they mount are deliberately still eager.
+mountOnFirstOpen(
+  () => externalToolsCtrl.open,
+  () => import("./islands/externaltools/ExternalTools.svelte"),
+);
 // Plugins manager (PER-49 follow-up): the installed-plugin registry moved out
 // of the old Settings → Plugins tab into its own VS Code Extensions-style
 // two-pane view — app-level (no repo needed) like External Tools/Dashboard, so
 // the same on-demand-modal + Tools-menu/⌘K treatment. It OWNS the plugin list;
 // the Settings Tama skin picker now reads pluginsCtrl.plugins.
-mount(Plugins, { target: document.body });
+mountOnFirstOpen(() => pluginsCtrl.open, () => import("./islands/plugins/Plugins.svelte"));
 // App Settings: theme/cherry-pick-default/auto-update-check prefs (app-level,
 // like External Tools/Dashboard above) plus a Git Identity section scoped to
 // whichever repo is open (forwards bridge.CUR_REPO, like Remotes) — see
 // settings.svelte.ts's own header doc for why these live in localStorage
 // rather than a new Rust settings file.
-mount(Settings, { target: document.body });
+mountOnFirstOpen(() => settingsCtrl.open, () => import("./islands/settings/Settings.svelte"));
 // fsck-based dangling-object recovery (backlog #13): same on-demand-modal
 // treatment as External Tools/Dashboard/Pickaxe Search/Export Patches/
 // Remotes/Reflog/Rerere/Plumbing above — repo-scoped (forwards
@@ -266,7 +272,10 @@ mount(Terminal, { target: document.body });
 // doc) — same on-demand-modal treatment as every other one above, but with
 // no menu/⌘K entry point anywhere; legacy/main.ts's own click-counter on
 // the nook portrait is the only way in.
-mount(TamaGallery, { target: document.body });
+mountOnFirstOpen(
+  () => tamaGalleryCtrl.open,
+  () => import("./islands/tamagallery/TamaGallery.svelte"),
+);
 
 // Native app menu -> frontend action bridge (see src-tauri/src/menu.rs).
 // Only the items whose action lives in Svelte-controller land forward here —


### PR DESCRIPTION
Closes #81. Establishes the pattern that #82 (Terminal) and #83 (non-body mounts) follow.

## What moved

`TamaGallery`, `Plugins`, `Settings`, `ExternalTools` — the four the issue scoped as "no special mounting". Only the **views** move; the controllers stay eager, because boot code reads them (menu wiring, ⌘K registration, settings applied to the document).

That split is what makes this cheap. `open` is plain `$state` on a singleton that already exists, so `mountOnFirstOpen(() => ctrl.open, () => import(...))` needs no new plumbing on either side.

## What I checked before moving each one

Deferring a mount defers whatever that mount did, so eligibility is not a matter of taste:

- None of the four views has an `onMount`, an `$effect`, an `addEventListener`, or a prop. They are pure presentation.
- `open` is assigned **only** inside each controller's own module — grepped across `src/` — so watching it is a complete trigger, not one entry point among several.
- All four mounted identically: `mount(X, { target: document.body })`, no props.

`lazyisland.svelte.ts` states that bar in its header, because the failure mode for getting it wrong is silent: the work simply stops happening until someone opens the modal.

## Measured, on a production build

| | before | after | delta |
| --- | --- | --- | --- |
| boot JS | 1743.54 kB | 1698.97 kB | **−44.56 kB** (−11.75 kB gzip) |
| boot CSS | 20.34 kB | 16.51 kB | **−3.83 kB** |
| **boot total** | | | **−48.39 kB raw, −12.45 kB gzip** |
| chunks | 5 | 10 | |

The four chunks total 48.87 kB, so this is a *move*, not a saving. The point is that none of it is on the boot path any more.

The issue's headline figures (214 → 122 ms DCL, 1151 → 889 DOM nodes) are for the full modal batch and need a browser to reproduce; I could not run one here, so I am not restating them as if I had.

## Two things worth deciding on rather than inheriting

**The first open waits for its chunk.** Off the local asset protocol that is well under a frame, but it does mean the first open of a modal does not animate its scrim in, because there is no scrim in the DOM yet to animate. Subsequent opens are exactly as before. If that bothers you, a `requestIdleCallback` prefetch after boot would keep the chunk warm without putting it back on the boot path — I left it out as scope.

**A failed chunk load clears the guard and logs** rather than becoming an unhandled rejection. Worth naming because I flagged exactly this shape in #94's locale loader, and it would have been the same mistake here.

## Tests

A new e2e spec asserting the property that actually distinguishes this change: the four are **absent from the DOM** at boot, not merely hidden. `toBeHidden()` passes for both "mounted and hidden" and "not mounted", so it cannot tell the old behaviour from the new one; `toHaveCount(0)` can. It also checks that opening one mounts exactly that one — not its siblings, which is what a single shared chunk would have done — and that close/reopen does not produce a second copy in `document.body`.

The existing `settings-shortcut.spec.ts` is an independent guard that the modal still actually opens.

⚠️ **The new spec has not been run locally** — the Playwright browser download fails here with `ECONNRESET`, so CI is its first execution. `svelte-check` is clean and all 1526 unit tests pass.
