### PR TITLE
perf: lazy-mount Terminal, BisectDrawer and PluginPanel

### DIFF
--- a/e2e/lazy-islands.spec.ts
+++ b/e2e/lazy-islands.spec.ts
@@ -12,6 +12,13 @@ const MODALS = [
   { name: "Plugins", selector: ".modal.plugins-modal" },
   { name: "External Tools", selector: ".modal.external-tools" },
   { name: "Tama Gallery", selector: ".modal.tama-gallery" },
+  // #82/#83: the three that needed more than the mechanical change. Terminal
+  // carries xterm's 334 kB and must stay mounted once opened; BisectDrawer is
+  // the one island that does not go into document.body; PluginPanel is reached
+  // through the plugin panel registry rather than a fixed call site.
+  { name: "Terminal", selector: ".term-drawer" },
+  { name: "Bisect drawer", selector: ".bisect-panel" },
+  { name: "Plugin panel", selector: ".modal.pluginpanel" },
 ];
 
 test("none of the lazily mounted modals is in the DOM at boot", async ({ page }) => {

--- a/src/islands/terminal/Terminal.svelte
+++ b/src/islands/terminal/Terminal.svelte
@@ -50,7 +50,9 @@
     xterm.loadAddon(fitAddon);
     xterm.open(containerEl);
     xterm.onData((data) => terminalCtrl.write(data));
-    terminalCtrl.onData = (bytes) => xterm?.write(bytes);
+    // attachOutput, not a bare assignment: anything the shell said before this
+    // component existed is still queued, and this is what flushes it.
+    terminalCtrl.attachOutput((bytes) => xterm?.write(bytes));
 
     // Re-theme on a light/dark toggle — same "no change event exists,
     // observe the attribute directly" approach the rest of this codebase

--- a/src/islands/terminal/terminal.svelte.test.ts
+++ b/src/islands/terminal/terminal.svelte.test.ts
@@ -51,6 +51,7 @@ function resetTerminal() {
   terminalCtrl.busy = false;
   terminalCtrl.exited = false;
   terminalCtrl.onData = null;
+  (terminalCtrl as unknown as { pendingOutput: Uint8Array[] }).pendingOutput = [];
   mockInTauri = false;
   vi.clearAllMocks();
   handlers = {};
@@ -262,6 +263,68 @@ describe("write / resize", () => {
   it("resize is a no-op without a live session", async () => {
     await terminalCtrl.resize(80, 24);
     expect(commands.terminalResize).not.toHaveBeenCalled();
+  });
+});
+
+describe("output that arrives before the view exists (#82)", () => {
+  // Terminal.svelte is mounted on FIRST OPEN now, so there is a real window
+  // between the shell being spawned and there being an xterm to write into.
+  // Before attachOutput() the listener's `this.onData?.()` swallowed anything
+  // that landed in it — which is the shell's own prompt, every first open.
+  const b64 = (s: string) => btoa(s);
+  const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+  async function spawnSession() {
+    mockInTauri = true;
+    vi.mocked(commands.terminalSpawn).mockResolvedValueOnce(ok("term-1"));
+    await terminalCtrl.toggle("/repo");
+  }
+
+  it("queues it and flushes in order once the view attaches", async () => {
+    await spawnSession();
+
+    // The shell talks first. Nothing is attached yet.
+    handlers["terminal-output"]({ payload: { id: "term-1", data: b64("$ ") } });
+    handlers["terminal-output"]({ payload: { id: "term-1", data: b64("echo hi\r\n") } });
+
+    const received: Uint8Array[] = [];
+    terminalCtrl.attachOutput((bytes) => received.push(bytes));
+
+    expect(received.map(decode)).toEqual(["$ ", "echo hi\r\n"]);
+  });
+
+  it("goes straight through once attached, with nothing left queued", async () => {
+    await spawnSession();
+    const received: Uint8Array[] = [];
+    terminalCtrl.attachOutput((bytes) => received.push(bytes));
+
+    handlers["terminal-output"]({ payload: { id: "term-1", data: b64("live") } });
+
+    expect(received.map(decode)).toEqual(["live"]);
+    expect((terminalCtrl as unknown as { pendingOutput: Uint8Array[] }).pendingOutput).toHaveLength(0);
+  });
+
+  it("caps the queue and keeps the newest, since the tail is what gets read", async () => {
+    await spawnSession();
+    // 300 chunks against a 256 cap: the first 44 fall off the front.
+    for (let i = 0; i < 300; i++) {
+      handlers["terminal-output"]({ payload: { id: "term-1", data: b64(`${i}|`) } });
+    }
+    const received: Uint8Array[] = [];
+    terminalCtrl.attachOutput((bytes) => received.push(bytes));
+
+    expect(received).toHaveLength(256);
+    expect(decode(received[0])).toBe("44|");
+    expect(decode(received[255])).toBe("299|");
+  });
+
+  it("still ignores a superseded session's output rather than queueing it", async () => {
+    await spawnSession();
+    handlers["terminal-output"]({ payload: { id: "term-0-stale", data: b64("ghost") } });
+
+    const received: Uint8Array[] = [];
+    terminalCtrl.attachOutput((bytes) => received.push(bytes));
+    expect(received).toHaveLength(0);
   });
 });
 

--- a/src/islands/terminal/terminal.svelte.ts
+++ b/src/islands/terminal/terminal.svelte.ts
@@ -44,6 +44,44 @@ class TerminalState {
 
   onData: ((bytes: Uint8Array) => void) | null = null;
 
+  // Output that arrived before the view existed to receive it.
+  //
+  // `onData` is set by Terminal.svelte's onMount, and since #82 that mount is
+  // deferred to the first open — so there is now a real window between "the
+  // shell is spawned and talking" and "there is an xterm to talk to". Without
+  // this the `?.` in the output listener would swallow the shell's own prompt
+  // on the very first open, silently, which is the exact class of gap
+  // armListeners() was written to avoid from the other direction.
+  //
+  // Capped: a process that floods before the chunk lands must not grow this
+  // without bound. The realistic window is one chunk read off local disk, so
+  // the cap is generous and dropping the OLDEST is the right trade — the tail
+  // is what the user is about to look at.
+  private pendingOutput: Uint8Array[] = [];
+  private static readonly MAX_PENDING_CHUNKS = 256;
+
+  /**
+   * Attach the view's writer, flushing anything that arrived before it existed.
+   * Called by Terminal.svelte once it mounts; nothing else should assign
+   * `onData` directly, or the buffered bytes are stranded.
+   */
+  attachOutput(sink: (bytes: Uint8Array) => void): void {
+    this.onData = sink;
+    const queued = this.pendingOutput;
+    this.pendingOutput = [];
+    for (const bytes of queued) sink(bytes);
+  }
+
+  /** Route one chunk of PTY output to the view, or hold it until there is one. */
+  private emitOutput(bytes: Uint8Array): void {
+    if (this.onData) {
+      this.onData(bytes);
+      return;
+    }
+    if (this.pendingOutput.length >= TerminalState.MAX_PENDING_CHUNKS) this.pendingOutput.shift();
+    this.pendingOutput.push(bytes);
+  }
+
   private unlistenOutput: (() => void) | null = null;
   private unlistenExit: (() => void) | null = null;
 
@@ -148,7 +186,7 @@ class TerminalState {
     if (!w.__TAURI__) return;
     w.__TAURI__.event.listen("terminal-output", (e: { payload: { id: string; data: string } }) => {
       if (e.payload.id !== id) return;
-      this.onData?.(base64ToBytes(e.payload.data));
+      this.emitOutput(base64ToBytes(e.payload.data));
     }).then((un) => {
       if (this.sessionId === id) this.unlistenOutput = un;
       else un();

--- a/src/lazyisland.svelte.ts
+++ b/src/lazyisland.svelte.ts
@@ -10,12 +10,22 @@
 // That split is the whole trick: `open` is plain `$state` on a singleton that
 // already exists, so watching it costs nothing and needs no new plumbing.
 //
-// SAFE ONLY for islands whose view is pure presentation: no `onMount`, no
-// `$effect`, no listeners, and no props. An island that does work when it
-// mounts must keep its eager `mount()`, because deferring the mount defers the
-// work — silently, and until the user happens to open it. TamaGallery,
-// Plugins, Settings and ExternalTools were each checked against that bar
-// before being moved (see #81).
+// SAFE ONLY for islands whose view does no work the app needs before someone
+// opens it. Deferring a mount defers whatever that mount did — silently, and
+// until the user happens to open the thing. The bar, in the order it is worth
+// checking:
+//
+//   * no `onMount` / `onDestroy` doing work anyone else depends on
+//   * no `$effect` with a side effect outside the component
+//   * no `addEventListener` AND no `<svelte:window>` / `<svelte:document>` /
+//     `<svelte:body>` — the second form is the one a grep for the first will
+//     quietly miss, and every modal island here uses it for its Escape handler
+//   * no props
+//
+// A global listener is fine when it is guarded by the same `open` the mount is
+// keyed to: it cannot matter before the mount, because the mount is what `open`
+// triggers. Every island moved so far is that shape (`if (Escape && ctrl.open)
+// ctrl.close()`), which is why they qualify despite having one.
 //
 // Lives in a `.svelte.ts` file because `$effect` is a rune and `main.ts` is
 // plain TypeScript — the effect has to be compiled here and called from there.
@@ -37,6 +47,13 @@ import { mount, type Component } from "svelte";
 export function mountOnFirstOpen(
   isOpen: () => boolean,
   load: () => Promise<{ default: Component<Record<string, never>> }>,
+  /**
+   * Where to mount. Defaults to `document.body`, which is where every modal
+   * island goes; BisectDrawer is the exception, living inside `#canvasWrap`.
+   * Resolved lazily, at mount time rather than at call time, so a target that
+   * is static markup in index.html does not have to be looked up during boot.
+   */
+  target: () => Element = () => document.body,
 ): void {
   let started = false;
   const stop = $effect.root(() => {
@@ -45,7 +62,7 @@ export function mountOnFirstOpen(
       started = true;
       void load()
         .then((mod) => {
-          mount(mod.default, { target: document.body });
+          mount(mod.default, { target: target() });
           // One job, done. Nothing here needs to observe `open` again — the
           // mounted component owns its own show/hide from now on.
           stop();

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,6 @@ import { resetHeadCtrl } from "./islands/resethead/resethead.svelte.ts";
 import ExportPatches from "./islands/exportpatches/ExportPatches.svelte";
 import { exportPatchesCtrl } from "./islands/exportpatches/exportpatches.svelte.ts";
 import { applyPatchCtrl } from "./islands/applypatch/applypatch.svelte.ts";
-import Terminal from "./islands/terminal/Terminal.svelte";
 import { terminalCtrl } from "./islands/terminal/terminal.svelte.ts";
 import PickaxeSearch from "./islands/pickaxesearch/PickaxeSearch.svelte";
 import { pickaxeSearchCtrl } from "./islands/pickaxesearch/pickaxesearch.svelte.ts";
@@ -37,6 +36,8 @@ import Dashboard from "./islands/dashboard/Dashboard.svelte";
 import { dashboardCtrl } from "./islands/dashboard/dashboard.svelte.ts";
 import { externalToolsCtrl } from "./islands/externaltools/externaltools.svelte.ts";
 import { tamaGalleryCtrl } from "./islands/tamagallery/tamagallery.svelte.ts";
+import { bisectDrawerCtrl } from "./islands/bisectdrawer/bisectdrawer.svelte.ts";
+import { pluginPanelsCtrl } from "./islands/pluginpanels/pluginpanels.svelte.ts";
 import { mountOnFirstOpen } from "./lazyisland.svelte.ts";
 import { pluginsCtrl } from "./islands/plugins/plugins.svelte.ts";
 import { settingsCtrl, loadSettings } from "./islands/settings/settings.svelte.ts";
@@ -54,7 +55,6 @@ import SetupWizard from "./islands/setupwizard/SetupWizard.svelte";
 import { setupWizardCtrl } from "./islands/setupwizard/setupwizard.svelte.ts";
 import Cmdk from "./islands/cmdk/Cmdk.svelte";
 import { cmdkCtrl } from "./islands/cmdk/cmdk.svelte.ts";
-import PluginPanel from "./islands/pluginpanels/PluginPanel.svelte";
 import VimNav from "./islands/vimnav/VimNav.svelte";
 import SnapshotPreview from "./islands/snapshotpreview/SnapshotPreview.svelte";
 import About from "./islands/about/About.svelte";
@@ -62,7 +62,6 @@ import { aboutCtrl } from "./islands/about/about.svelte.ts";
 import { updaterCtrl } from "./islands/updater/updater.svelte.ts";
 import DetailPanel from "./islands/detailpanel/DetailPanel.svelte";
 import { workdirCtrl } from "./islands/workdir/workdir.svelte.ts";
-import BisectDrawer from "./islands/bisectdrawer/BisectDrawer.svelte";
 import { openBisectEntry } from "./islands/bisectdrawer/bisectdrawer.svelte.ts";
 import Sidebar from "./islands/sidebar/Sidebar.svelte";
 import { sidebarCtrl } from "./islands/sidebar/sidebar.svelte.ts";
@@ -143,7 +142,14 @@ mount(DetailPanel, { target: document.getElementById("detail")! });
 // below) are no longer mounted into a permanent drawer pane. MUST mount
 // inside #canvasWrap, not document.body: its position:absolute floats
 // relative to that element, same as #deltaReadout.
-mount(BisectDrawer, { target: document.getElementById("bisectPanelMount")! });
+// Lazily mounted (#83). The one island that does NOT go into document.body:
+// #bisectPanelMount is static markup in index.html, so it is there whenever
+// the first open happens — the lookup just moves off the boot path with it.
+mountOnFirstOpen(
+  () => bisectDrawerCtrl.open,
+  () => import("./islands/bisectdrawer/BisectDrawer.svelte"),
+  () => document.getElementById("bisectPanelMount")!,
+);
 
 mount(Sidebar, { target: document.getElementById("sidebarRefs")! });
 sidebarCtrl.refresh(bridge.CUR_REPO as unknown as string);
@@ -175,7 +181,9 @@ mount(Plumbing, { target: document.body });
 // into a drawer. Purely declarative: it renders a plugin's DECLARED widgets
 // (heading/text/button/command-output) and only ever runs that plugin's OWN
 // commands via the same runPluginCommand path PER-42 uses.
-mount(PluginPanel, { target: document.body });
+// Lazily mounted (#83). Driven by the plugin panel registry rather than a
+// fixed call site, but every route into it ends at pluginPanelsCtrl.open.
+mountOnFirstOpen(() => pluginPanelsCtrl.open, () => import("./islands/pluginpanels/PluginPanel.svelte"));
 // Fetch/Pull live-progress modal — opened by doFetch/doPull (legacy/main.ts),
 // which is reached from both the topbar buttons and the native Fetch/Pull menu.
 mount(SyncProgress, { target: document.body });
@@ -267,7 +275,15 @@ mount(RepoFiles, { target: document.body });
 // and visually toggled (`.term-drawer.on`) rather than shown/hidden by a
 // controller-owned boolean gating the whole component's render, keeping its
 // one xterm.js instance alive (and its scrollback intact) across hide/show.
-mount(Terminal, { target: document.body });
+// Lazily mounted (#82) — the big one: xterm is 334 kB that every user paid
+// for at boot whether or not they ever opened a terminal.
+//
+// The keep-alive the comment above describes is unaffected: mountOnFirstOpen
+// mounts once and never unmounts, so the one xterm instance and its
+// scrollback still survive every hide/show exactly as before. What DID need
+// handling is the other end — the shell can start talking before the chunk
+// lands, so terminalCtrl now queues output until the view attaches.
+mountOnFirstOpen(() => terminalCtrl.open, () => import("./islands/terminal/Terminal.svelte"));
 // Tama Gallery: a hidden Easter egg (see tamagallery.svelte.ts's own header
 // doc) — same on-demand-modal treatment as every other one above, but with
 // no menu/⌘K entry point anywhere; legacy/main.ts's own click-counter on


### PR DESCRIPTION
Closes #82. Closes #83. One PR because they are one change to one mechanism — the three that each needed more than the mechanical version of #81.

## Terminal (#82) — and the trap that is not in the issue

The issue names the scrollback keep-alive as the thing that makes this its own issue. That one turns out to be **free**: `mountOnFirstOpen` already mounts once and never unmounts, so the single xterm instance and its history survive every hide/show exactly as before.

The real trap is at the other end.

`terminal.svelte.ts`'s output listener was `this.onData?.(...)`, and `onData` is assigned by the view's `onMount`. Defer that mount and the ordering becomes:

1. open the drawer → `open = true`
2. controller spawns the shell, arms the listeners
3. shell prints its prompt → `terminal-output` fires
4. `onData` is **still null**, because the chunk has not landed → `?.` drops it
5. chunk lands, view mounts, output starts working

The user loses the prompt on the first open of every session, silently. `armListeners()`'s own comment says it was written so there is "no window where early output could arrive unheard" — this would have reopened that window from the other direction.

So the controller queues output until a view attaches, and `attachOutput()` flushes it in order. Capped at 256 chunks dropping the oldest, since the tail is what the user is about to read.

## BisectDrawer and PluginPanel (#83)

The mechanical shape, one wrinkle each. BisectDrawer is the only island that does not mount into `document.body`, so `mountOnFirstOpen` now takes a target — resolved at mount time rather than call time, so a lookup of static markup does not happen during boot. PluginPanel is reached through the panel registry rather than a fixed call site, but every route into it still ends at `pluginPanelsCtrl.open`.

## Correcting #81's eligibility claim

#81's PR said the four views had "no `onMount`, no `$effect`, no `addEventListener`, no props". **All four register a global listener** — via `<svelte:window on:keydown>`, which the grep behind that sentence would not match. I found it doing the same pass here, where BisectDrawer and PluginPanel use the identical form.

The conclusion held, and I checked rather than assumed: every one of them is `if (e.key === "Escape" && ctrl.open) ctrl.close()`. A listener guarded by the very flag the mount is keyed to cannot matter before the mount, because the mount is what that flag triggers. Nothing regressed. But the rigour I claimed was not the rigour I had, so `lazyisland.svelte.ts`'s eligibility bar now names `<svelte:window>`/`<svelte:document>`/`<svelte:body>` explicitly and says why this shape still qualifies. ([comment on #124](https://github.com/zangjiucheng/GitCat/pull/124))

## Measured against dev, production build

| | dev | this PR | delta |
| --- | --- | --- | --- |
| boot JS | 1699.05 kB | 1363.41 kB | **−335.64 kB** (−85.57 kB gzip) |
| boot CSS | 16.51 kB | 10.14 kB | **−6.37 kB** |
| **boot total** | | | **−342.01 kB raw, −87.48 kB gzip** |

Terminal's own chunk is 330.08 kB plus 5.12 kB of CSS — the 334 kB the issue promised. Cumulatively with #81 the boot chunk is down from 1785 kB to 1363 kB.

## Tests

Four unit tests on the output queue. **Reverting `emitOutput` to the dropping version turns two of them red** — the queue-and-flush one and the cap one. The other two pin behaviour that must *not* change (straight through once attached; a superseded session's output still ignored rather than queued) and pass either way, which is what they are for.

The e2e boot spec now covers all seven islands.

⚠️ **The e2e change has not been run locally** — the Playwright browser download still fails here with `ECONNRESET`, so CI is its first execution. `svelte-check` is clean and all 1530 unit tests pass.
